### PR TITLE
extend config to contain mqtt settings

### DIFF
--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -12,3 +12,10 @@ domains:
   - ffmuc_uml_west
   - ffmuc_welt
 pubkeys_file: /var/lib/wgke/public.keys
+mqtt:
+  broker_url: broker.example.com
+  broker_port: 1883
+  username: user
+  password: SECRET
+  keppalive: 5
+  tls: False

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -4,10 +4,22 @@ import sys
 import yaml
 from voluptuous import All, MultipleInvalid, Required, Schema
 
+MQTT_SCHEMA = Schema(
+    {
+        Required("broker_url"): str,
+        Required("broker_port", default=1883): int,
+        Required("username", default=""): str,
+        Required("password", default=""): str,
+        Required("keepalive", default=5): int,
+        Required("tls", default=False): bool,
+    }
+)
+
 CONFIG_SCHEMA = Schema(
     {
         Required("domains"): All([str], min=1),
-        Required("pubkeys_file", default="/var/lib/wgkex/public.keys"): str,
+        Required("pubkeys_file", default=""): str,
+        Required("mqtt"): MQTT_SCHEMA,
     }
 )
 


### PR DESCRIPTION
In case we want to go the way to run via mqtt the config needs to be extended.

#25 should rebase on this to make the broker_url configurable by config file