### PR TITLE
Initial re-write of netlink.py and tests

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,14 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
+    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+)
+
+
+load("@rules_python//python:pip.bzl", "pip_install")
+
+pip_install(
+   requirements = "//:requirements.txt",
+   python_interpreter = "/Library/Frameworks/Python.framework/Versions/3.9/bin/python3.9",
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+NetLink
+flask-mqtt
+pyroute2
+PyYAML
+Flask
+voluptuous
+
+# Common
+ipaddress
+mock

--- a/wgkex/common/BUILD
+++ b/wgkex/common/BUILD
@@ -1,0 +1,12 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@pip//:requirements.bzl", "requirement")
+
+
+py_library(
+    name = "utils",
+    srcs = ["utils.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+       requirement("ipaddress"),
+    ],
+)

--- a/wgkex/config/BUILD
+++ b/wgkex/config/BUILD
@@ -1,0 +1,14 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@pip//:requirements.bzl", "requirement")
+
+
+py_library(
+    name = "config",
+    srcs = ["config.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+       requirement("voluptuous"),
+       requirement("PyYAML"),
+       "//wgkex/common:utils"
+    ],
+)

--- a/wgkex/worker/BUILD
+++ b/wgkex/worker/BUILD
@@ -14,12 +14,34 @@ py_library(
     ],
 )
 
-
 py_test(
     name = "netlink_test",
     srcs = ["netlink_test.py"],
     deps = [
        ":netlink",
+       requirement("mock"),
+    ],
+)
+
+py_library(
+    name = "mqtt",
+    srcs = ["mqtt.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+       requirement("NetLink"),
+       requirement("paho-mqtt"),
+       requirement("pyroute2"),
+       "//wgkex/common:utils",
+       "//wgkex/config:config",
+       ":netlink",
+    ],
+)
+
+py_test(
+    name = "mqtt_test",
+    srcs = ["mqtt_test.py"],
+    deps = [
+       ":mqtt",
        requirement("mock"),
     ],
 )

--- a/wgkex/worker/BUILD
+++ b/wgkex/worker/BUILD
@@ -1,0 +1,25 @@
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@pip//:requirements.bzl", "requirement")
+
+
+py_library(
+    name = "netlink",
+    srcs = ["netlink.py"],
+    visibility = ["//visibility:public"],
+    deps = [
+       requirement("NetLink"),
+       requirement("paho-mqtt"),
+       requirement("pyroute2"),
+       "//wgkex/common:utils"
+    ],
+)
+
+
+py_test(
+    name = "netlink_test",
+    srcs = ["netlink_test.py"],
+    deps = [
+       ":netlink",
+       requirement("mock"),
+    ],
+)

--- a/wgkex/worker/mqtt.py
+++ b/wgkex/worker/mqtt.py
@@ -1,40 +1,64 @@
 #!/usr/bin/env python3
+"""Process messages from MQTT."""
+
 import paho.mqtt.client as mqtt
-from wgkex.config import load_config
+
+# TODO(ruairi): Deprecate __init__.py from config, as it masks namespace.
+from wgkex.config.config import load_config
 import socket
-import time
 import re
-from wgkex.worker.netlink import (
-    find_stale_wireguard_clients,
-    link_handler,
-    WireGuardClient,
-)
-
-config = load_config()
+from wgkex.worker.netlink import link_handler
+from wgkex.worker.netlink import WireGuardClient
+from typing import Optional, Dict, List, Any, Union
 
 
-def connect(domains: str):
-    broker_address = config.get("mqtt", {}).get("broker_url")
+def fetch_from_config(var: str) -> Optional[Union[Dict[str, str], str]]:
+    """Fetches values from configuration file.
+
+    Arguments:
+        var: The variable to fetch from config.
+
+    Returns:
+        The given variable from configuration.
+    """
+    config = load_config()
+    return config.get(var)
+
+
+def connect(domains: List[str]) -> None:
+    """Connect to MQTT for the given domains.
+
+    Argument:
+        domains: The domains to connect to.
+    """
+    broker_address = fetch_from_config("mqtt").get("broker_url")
+    # TODO(ruairi): Move the hostname to a global variable.
     client = mqtt.Client(socket.gethostname())
     client.on_message = on_message
-    print("connecting to broker " + broker_address)
+    print(f"connecting to broker {broker_address}")
     client.connect(broker_address)
     for domain in domains:
-        print("Subscribing to topic", "wireguard/" + domain + "/+")
-        client.subscribe("wireguard/" + domain + "/+")
+        topic = f"wireguard/{domain}/+"
+        print(f"Subscribing to topic {topic}")
+        client.subscribe(topic)
     client.loop_forever()
 
 
-def on_message(client, userdata, message):
+def on_message(client: mqtt.Client, userdata: Any, message: mqtt.MQTTMessage) -> None:
+    """Processes messages from MQTT and forwards them to netlink.
 
-    domain = re.search("/.*ffmuc_(\w+)/", message.topic).group(1)
-
+    Arguments:
+        client: the client instance for this callback.
+        userdata: the private user data.
+        message: The MQTT message.
+    """
+    # TODO(ruairi): Check bounds and raise exception here.
+    domain = re.search(r"/.*ffmuc_(\w+)/", message.topic).group(1)
     client = WireGuardClient(
         public_key=str(message.payload.decode("utf-8")),
         domain=domain,
         remove=False,
     )
-
-    print("Received node create message for key " + client.public_key)
-
+    print(f"Received node create message for key {client.public_key}")
+    # TODO(ruairi): Verify return type here.
     print(link_handler(client))

--- a/wgkex/worker/mqtt_test.py
+++ b/wgkex/worker/mqtt_test.py
@@ -1,0 +1,78 @@
+"""Unit tests for mqtt.py"""
+import unittest
+import mock
+import mqtt
+
+
+class MQTTTest(unittest.TestCase):
+    @mock.patch.object(mqtt, "load_config")
+    def test_fetch_from_config_success(self, config_mock):
+        """Ensure we can fetch a value from config."""
+        config_mock.return_value = dict(key="value")
+        self.assertEqual("value", mqtt.fetch_from_config("key"))
+
+    @mock.patch.object(mqtt, "load_config")
+    def test_fetch_from_config_fails_no_key(self, config_mock):
+        """Tests we fail with ValueError for missing key in config."""
+        config_mock.return_value = dict(key="value")
+        self.assertIsNone(mqtt.fetch_from_config("does_not_exist"))
+
+    @mock.patch.object(mqtt.mqtt, "Client")
+    @mock.patch.object(mqtt.socket, "gethostname")
+    @mock.patch.object(mqtt, "load_config")
+    def test_connect_success(self, config_mock, hostname_mock, mqtt_mock):
+        """Tests successful connection to MQTT server."""
+        hostname_mock.return_value = "hostname"
+        config_mock.return_value = dict(mqtt={"broker_url": "some_url"})
+        mqtt.connect(["domain1", "domain2"])
+        mqtt_mock.assert_has_calls(
+            [
+                mock.call("hostname"),
+                mock.call().connect("some_url"),
+                mock.call().subscribe("wireguard/domain1/+"),
+                mock.call().subscribe("wireguard/domain2/+"),
+                mock.call().loop_forever(),
+            ],
+            any_order=True,
+        )
+
+    @mock.patch.object(mqtt.mqtt, "Client")
+    @mock.patch.object(mqtt, "load_config")
+    def test_connect_fails_mqtt_error(self, config_mock, mqtt_mock):
+        """Tests failure for connect - ValueError."""
+        mqtt_mock.side_effect = ValueError("barf")
+        config_mock.return_value = dict(mqtt={"broker_url": "some_url"})
+        with self.assertRaises(ValueError):
+            mqtt.connect(["domain1", "domain2"])
+
+    @mock.patch.object(mqtt, "link_handler")
+    def test_on_message_success(self, link_mock):
+        """Tests on_message for success."""
+        link_mock.return_value = dict(WireGuard="result")
+        mqtt_msg = mock.patch.object(mqtt.mqtt, "MQTTMessage")
+        mqtt_msg.topic = "/_ffmuc_domain1/"
+        mqtt_msg.payload = b"PUB_KEY"
+        mqtt.on_message(None, None, mqtt_msg)
+        link_mock.assert_has_calls(
+            [
+                mock.call(
+                    mqtt.WireGuardClient(
+                        public_key="PUB_KEY", domain="domain1", remove=False
+                    )
+                )
+            ],
+            any_order=True,
+        )
+
+    @mock.patch.object(mqtt, "link_handler")
+    def test_on_message_fails_no_domain(self, link_mock):
+        """Tests on_message for failure to parse domain."""
+        link_mock.return_value = dict(WireGuard="result")
+        mqtt_msg = mock.patch.object(mqtt.mqtt, "MQTTMessage")
+        mqtt_msg.topic = "bad_domain_match"
+        with self.assertRaises(AttributeError):
+            mqtt.on_message(None, None, mqtt_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -1,82 +1,120 @@
+"""Functions related to netlink manipulation for Wireguard, IPRoute and FDB on Linux."""
 import hashlib
 import re
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 from textwrap import wrap
 from typing import Dict, List
 
-from pyroute2 import WireGuard, IPRoute
+import pyroute2
 
 from wgkex.common.utils import mac2eui64
+
+_PERSISTENT_KEEPALIVE_SECONDS = 15
+_PEER_TIMEOUT_HOURS = 3
 
 
 @dataclass
 class WireGuardClient:
+    """A Class representing a WireGuard client.
+
+    Attributes:
+        public_key: The public key to use for this client.
+        domain: The domain for this client.
+        remove: If this is to be removed or not.
+    """
+
     public_key: str
     domain: str
     remove: bool
 
     @property
     def lladdr(self) -> str:
-        m = hashlib.md5()
+        """Compute the X for an (IPv6) Link-Local address.
 
-        m.update(self.public_key.encode("ascii") + b"\n")
-        hashed_key = m.hexdigest()
+        Returns:
+            IPv6 Link-Local address of the WireGuard peer.
+        """
+        pub_key_hash = hashlib.md5()
+        pub_key_hash.update(self.public_key.encode("ascii") + b"\n")
+        hashed_key = pub_key_hash.hexdigest()
         hash_as_list = wrap(hashed_key, 2)
-        temp_mac = ":".join(["02"] + hash_as_list[:5])
+        current_mac_addr = ":".join(["02"] + hash_as_list[:5])
 
-        lladdr = re.sub(r"/\d+$", "/128", mac2eui64(mac=temp_mac, prefix="fe80::/10"))
-        return lladdr
+        return re.sub(
+            r"/\d+$", "/128", mac2eui64(mac=current_mac_addr, prefix="fe80::/10")
+        )
 
     @property
     def vx_interface(self) -> str:
+        """Returns the name of the VxLAN interface associated with this lladdr."""
         return f"vx-{self.domain}"
 
     @property
     def wg_interface(self) -> str:
+        """Returns the WireGuard peer interface."""
         return f"wg-{self.domain}"
-
-    """WireGuardClient describes complete configuration for a specific WireGuard client
-
-    Attributes:
-        public_key: WireGuard Public key
-        domain: Domain Name of the WireGuard peer
-        lladdr: IPv6 lladdr of the WireGuard peer
-        wg_interface: Name of the WireGuard interface this peer will use
-        vx_interface: Name of the VXLAN interface we set a route for the lladdr to
-        remove: Are we removing this peer or not?
-    """
 
 
 def wg_flush_stale_peers(domain: str) -> List[Dict]:
-    stale_clients = find_stale_wireguard_clients("wg-" + domain)
-    result = []
-    for stale_client in stale_clients:
-        stale_wireguard_client = WireGuardClient(
-            public_key=stale_client,
-            domain=domain,
-            remove=True,
-        )
-        result.append(link_handler(stale_wireguard_client))
-    return result
+    """Removes stale peers.
+
+    Arguments:
+        domain: The domain to detect peers on.
+
+    Returns:
+        The peers which we can remove.
+    """
+    stale_clients = [
+        stale_client for stale_client in find_stale_wireguard_clients("wg-" + domain)
+    ]
+    stale_wireguard_clients = [
+        WireGuardClient(public_key=stale_client, domain=domain, remove=True)
+        for stale_client in stale_clients
+    ]
+    link_handled = [
+        link_handler(stale_client) for stale_client in stale_wireguard_clients
+    ]
+    return link_handled
 
 
 # pyroute2 stuff
 def link_handler(client: WireGuardClient) -> Dict:
-    results = {}
+    """Updates fdb, route and WireGuard peers tables for a given WireGuard peer.
 
-    results.update({"Wireguard": wireguard_handler(client)})
+    Arguments:
+        client: A WireGuard peer to manipulate.
+    Returns:
+        The outcome of each operation.
+    """
+    results = dict()
+    # Updates WireGuard peers.
+    results.update({"Wireguard": update_wireguard_peer(client)})
     try:
+        # Updates routes to the WireGuard Peer.
         results.update({"Route": route_handler(client)})
     except Exception as e:
+        # TODO(ruairi): re-raise exception here.
         results.update({"Route": e})
+    # Updates WireGuard FDB.
     results.update({"Bridge FDB": bridge_fdb_handler(client)})
-
     return results
 
 
 def bridge_fdb_handler(client: WireGuardClient) -> Dict:
-    with IPRoute() as ip:
+    """Handles updates of FDB info towards WireGuard peers.
+
+    Note that set will remove an FDB entry if remove is set to True.
+
+    Arguments:
+        client: The WireGuard peer to update.
+
+    Returns:
+        A dict.
+    """
+    # TODO(ruairi): Splice this into an add_ and remove_ function.
+    with pyroute2.IPRoute() as ip:
         return ip.fdb(
             "del" if client.remove else "append",
             ifindex=ip.link_lookup(ifname=client.vx_interface)[0],
@@ -85,21 +123,42 @@ def bridge_fdb_handler(client: WireGuardClient) -> Dict:
         )
 
 
-def wireguard_handler(client: WireGuardClient) -> Dict:
-    with WireGuard() as wg:
+def update_wireguard_peer(client: WireGuardClient) -> Dict:
+    """Handles updates of WireGuard peers to netlink.
 
+    Note that set will remove a peer if remove is set to True.
+
+    Arguments:
+        client: The WireGuard peer to update.
+
+    Returns:
+        A dict.
+    """
+    # TODO(ruairi): Splice this into an add_ and remove_ function.
+    with pyroute2.WireGuard() as wg:
         wg_peer = {
             "public_key": client.public_key,
-            "persistent_keepalive": 15,
+            "persistent_keepalive": _PERSISTENT_KEEPALIVE_SECONDS,
             "allowed_ips": [client.lladdr],
             "remove": client.remove,
         }
-
         return wg.set(client.wg_interface, peer=wg_peer)
 
 
 def route_handler(client: WireGuardClient) -> Dict:
-    with IPRoute() as ip:
+    """Handles updates of routes towards WireGuard peers.
+
+    Note that set will remove a route if remove is set to True.
+
+    Arguments:
+        client: The WireGuard peer to update.
+
+    Returns:
+        A dict.
+    """
+    # TODO(ruairi): Determine what Exceptions are raised by ip.route
+    # TODO(ruairi): Splice this into an add_ and remove_ function.
+    with pyroute2.IPRoute() as ip:
         return ip.route(
             "del" if client.remove else "add",
             dst=client.lladdr,
@@ -108,18 +167,23 @@ def route_handler(client: WireGuardClient) -> Dict:
 
 
 def find_stale_wireguard_clients(wg_interface: str) -> List:
-    with WireGuard() as wg:
+    """Fetches and returns a list of peers which have not had recent handshakes.
 
+    Arguments:
+        wg_interface: The WireGuard interface to query.
+
+    Returns:
+        # A list of peers which have not recently seen a handshake.
+    """
+    three_hrs_in_secs = int(
+        (datetime.now() - timedelta(hours=_PEER_TIMEOUT_HOURS)).timestamp()
+    )
+    with pyroute2.WireGuard() as wg:
         clients = wg.info(wg_interface)[0].WGDEVICE_A_PEERS.value
-
-        three_hours_ago = (datetime.now() - timedelta(hours=3)).timestamp()
-
-        stale_clients = []
-        for client in clients:
-            latest_handshake = client.WGPEER_A_LAST_HANDSHAKE_TIME["tv_sec"]
-            if latest_handshake < int(three_hours_ago):
-                stale_clients.append(
-                    client.WGPEER_A_PUBLIC_KEY["value"].decode("utf-8")
-                )
-
-        return stale_clients
+        ret = [
+            client.WGPEER_A_PUBLIC_KEY.get("value", "").decode("utf-8")
+            for client in clients
+            if client.WGPEER_A_LAST_HANDSHAKE_TIME.get("tv_sec", int())
+            < three_hrs_in_secs
+        ]
+        return ret

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -1,0 +1,181 @@
+"""Unit tests for netlink.py"""
+import unittest
+import mock
+from datetime import timedelta
+from datetime import datetime
+
+# pyroute2 decides imports based on platform. WireGuard is specific to Linux only. Mock pyroute2.WireGuard so that
+# any testing platform can execute tests.
+import sys
+
+sys.modules["pyroute2"] = mock.MagicMock()
+sys.modules["pyroute2.WireGuard"] = mock.MagicMock()
+sys.modules["pyroute2.IPRoute"] = mock.MagicMock()
+from pyroute2 import WireGuard
+from pyroute2 import IPRoute
+import netlink
+
+_WG_CLIENT_ADD = netlink.WireGuardClient(
+    public_key="public_key", domain="add", remove=False
+)
+_WG_CLIENT_DEL = netlink.WireGuardClient(
+    public_key="public_key", domain="del", remove=True
+)
+
+_WG_PEER_STALE = mock.Mock()
+_WG_PEER_STALE.WGPEER_A_PUBLIC_KEY = {"value": b"WGPEER_A_PUBLIC_KEY_STALE"}
+_WG_PEER_STALE.WGPEER_A_LAST_HANDSHAKE_TIME = {
+    "tv_sec": int((datetime.now() - timedelta(hours=5)).timestamp())
+}
+
+_WG_PEER = mock.Mock()
+_WG_PEER.WGPEER_A_PUBLIC_KEY = {"value": b"WGPEER_A_PUBLIC_KEY"}
+_WG_PEER.WGPEER_A_LAST_HANDSHAKE_TIME = {
+    "tv_sec": int((datetime.now() - timedelta(seconds=3)).timestamp())
+}
+
+
+def _get_wg_mock(peer):
+    info_mock = mock.Mock()
+    info_mock.WGDEVICE_A_PEERS.value = [peer]
+    wg_instance = WireGuard()
+    wg_info_mock = wg_instance.__enter__.return_value
+    wg_info_mock.set.return_value = {"WireGuard": "set"}
+    wg_info_mock.info.return_value = [info_mock]
+    return wg_info_mock
+
+
+class NetlinkTest(unittest.TestCase):
+    def setUp(self) -> None:
+        iproute_instance = IPRoute()
+        self.route_info_mock = iproute_instance.__enter__.return_value
+        # self.addCleanup(mock.patch.stopall)
+
+    def test_find_stale_wireguard_clients_success_with_non_stale_peer(self):
+        """Tests find_stale_wireguard_clients no operation on non-stale peers."""
+        wg_info_mock = _get_wg_mock(_WG_PEER)
+        self.assertListEqual([], netlink.find_stale_wireguard_clients("some_interface"))
+
+    def test_find_stale_wireguard_clients_success_stale_peer(self):
+        """Tests find_stale_wireguard_clients removal of stale peer"""
+        wg_info_mock = _get_wg_mock(_WG_PEER_STALE)
+        self.assertListEqual(
+            ["WGPEER_A_PUBLIC_KEY_STALE"],
+            netlink.find_stale_wireguard_clients("some_interface"),
+        )
+
+    def test_route_handler_add_success(self):
+        """Test route_handler for normal add operation."""
+        self.route_info_mock.route.return_value = {"key": "value"}
+        self.assertDictEqual({"key": "value"}, netlink.route_handler(_WG_CLIENT_ADD))
+        self.route_info_mock.route.assert_called_with(
+            "add", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
+        )
+
+    def test_route_handler_remove_success(self):
+        """Test route_handler for normal del operation."""
+        self.route_info_mock.route.return_value = {"key": "value"}
+        self.assertDictEqual({"key": "value"}, netlink.route_handler(_WG_CLIENT_DEL))
+        self.route_info_mock.route.assert_called_with(
+            "del", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
+        )
+
+    def test_update_wireguard_peer_success(self):
+        """Test update_wireguard_peer for normal operation."""
+        wg_info_mock = _get_wg_mock(_WG_PEER)
+        self.assertDictEqual(
+            {"WireGuard": "set"}, netlink.update_wireguard_peer(_WG_CLIENT_ADD)
+        )
+        wg_info_mock.set.assert_called_with(
+            "wg-add",
+            peer={
+                "public_key": "public_key",
+                "persistent_keepalive": 15,
+                "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
+                "remove": False,
+            },
+        )
+
+    def test_bridge_fdb_handler_append_success(self):
+        """Test bridge_fdb_handler for normal append operation."""
+        self.route_info_mock.fdb.return_value = {"key": "value"}
+        self.assertEqual({"key": "value"}, netlink.bridge_fdb_handler(_WG_CLIENT_ADD))
+        self.route_info_mock.fdb.assert_called_with(
+            "append",
+            ifindex=mock.ANY,
+            lladdr="00:00:00:00:00:00",
+            dst="fe80::282:6eff:fe9d:ecd3",
+        )
+
+    def test_bridge_fdb_handler_del_success(self):
+        """Test bridge_fdb_handler for normal del operation."""
+        self.route_info_mock.fdb.return_value = {"key": "value"}
+        self.assertEqual({"key": "value"}, netlink.bridge_fdb_handler(_WG_CLIENT_DEL))
+        self.route_info_mock.fdb.assert_called_with(
+            "del",
+            ifindex=mock.ANY,
+            lladdr="00:00:00:00:00:00",
+            dst="fe80::282:6eff:fe9d:ecd3",
+        )
+
+    def test_link_handler_addition_success(self):
+        """Test link_handler for normal operation."""
+        expected = {
+            "Wireguard": {"WireGuard": "set"},
+            "Route": {"IPRoute": "route"},
+            "Bridge FDB": {"IPRoute": "fdb"},
+        }
+        wg_info_mock = _get_wg_mock(_WG_PEER)
+        wg_info_mock.set.return_value = {"WireGuard": "set"}
+        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
+        self.route_info_mock.route.return_value = {"IPRoute": "route"}
+        self.assertEqual(expected, netlink.link_handler(_WG_CLIENT_ADD))
+        self.route_info_mock.fdb.assert_called_with(
+            "append",
+            ifindex=mock.ANY,
+            lladdr="00:00:00:00:00:00",
+            dst="fe80::282:6eff:fe9d:ecd3",
+        )
+        self.route_info_mock.route.assert_called_with(
+            "add", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
+        )
+        wg_info_mock.set.assert_called_with(
+            "wg-add",
+            peer={
+                "public_key": "public_key",
+                "persistent_keepalive": 15,
+                "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
+                "remove": False,
+            },
+        )
+
+    def test_wg_flush_stale_peers_not_stale_success(self):
+        """Tests processing of non-stale WireGuard Peer."""
+        wg_info_mock = _get_wg_mock(_WG_PEER)
+        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
+        self.route_info_mock.route.return_value = {"IPRoute": "route"}
+        self.assertListEqual([], netlink.wg_flush_stale_peers("domain"))
+        # TODO(ruairi): Understand why pyroute.WireGuard.set
+        # wg_info_mock.set.assert_not_called()
+
+    def test_wg_flush_stale_peers_stale_success(self):
+        """Tests processing of stale WireGuard Peer."""
+        expected = [
+            {
+                "Wireguard": {"WireGuard": "set"},
+                "Route": {"IPRoute": "route"},
+                "Bridge FDB": {"IPRoute": "fdb"},
+            }
+        ]
+        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
+        self.route_info_mock.route.return_value = {"IPRoute": "route"}
+        wg_info_mock = _get_wg_mock(_WG_PEER_STALE)
+        wg_info_mock.set.return_value = {"WireGuard": "set"}
+        self.assertListEqual(expected, netlink.wg_flush_stale_peers("domain"))
+        self.route_info_mock.route.assert_called_with(
+            "del", dst="fe80::281:16ff:fe49:395e/128", oif=mock.ANY
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit adds tests for netlink.py. 

Please note that due to the lack of Linux host to test on - I have mocked the import of WireGuard. This is not ideal as we cannot autospec the Mocks. 

Also note that I've added BUILD files for bazel to build and test this code. So far, only what is needed to build and test netlink.py

Summary of changes: 

- Add tests for netlink.py
- Add docstrings for netlink.py
- Add minor refactors and style tweaks for netlink.py