### PR TITLE
Iterate over ALL wireguard peers

### DIFF
--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -179,7 +179,10 @@ def find_stale_wireguard_clients(wg_interface: str) -> List:
         (datetime.now() - timedelta(hours=_PEER_TIMEOUT_HOURS)).timestamp()
     )
     with pyroute2.WireGuard() as wg:
-        clients = wg.info(wg_interface)[0].WGDEVICE_A_PEERS.value
+        clients = []
+        infos = wg.info(wg_interface)
+        for info in infos:
+            clients.extend(info.WGDEVICE_A_PEERS.value)
         ret = [
             client.WGPEER_A_PUBLIC_KEY.get("value", "").decode("utf-8")
             for client in clients


### PR DESCRIPTION
This draft is based on https://github.com/freifunkh/wireguard-vxlan-glue/commit/7c876de05a30f4ff946065a34d5f9a63555d316f

Don't merge this yet, currently there's a bazel test failing, I'll look into it.

eventually this resolves #41


> Before this commit, only the first chunk of wireguard peers was
> processed. The following chunks of peers were silently discarded.
> 
> Currently we see chunks that approximately have a size of 90 peers.
> So you will only observe this issue if you have more than 90 peers.
> 
> note: this is a modified version in order to match wgkex code
> 
> Co-authored-by: "aiyion.prime" <git@aiyionpri.me>