### PR TITLE
worker: use get_attr and prevent TypeError

### DIFF
--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -179,14 +179,16 @@ def find_stale_wireguard_clients(wg_interface: str) -> List:
         (datetime.now() - timedelta(hours=_PEER_TIMEOUT_HOURS)).timestamp()
     )
     with pyroute2.WireGuard() as wg:
-        clients = []
+        all_clients = []
         infos = wg.info(wg_interface)
         for info in infos:
-            clients.extend(info.WGDEVICE_A_PEERS.value)
+            clients = info.get_attr("WGDEVICE_A_PEERS")
+            if clients is not None:
+                all_clients.extend(clients)
         ret = [
-            client.WGPEER_A_PUBLIC_KEY.get("value", "").decode("utf-8")
-            for client in clients
-            if client.WGPEER_A_LAST_HANDSHAKE_TIME.get("tv_sec", int())
+            client.get_attr("WGPEER_A_PUBLIC_KEY").decode("utf-8")
+            for client in all_clients
+            if client.get_attr("WGPEER_A_LAST_HANDSHAKE_TIME").get("tv_sec", int())
             < three_hrs_in_secs
         ]
         return ret


### PR DESCRIPTION
The `WG<XXX>` attributes are no longer present after
https://github.com/svinota/pyroute2/commit/3e485542722e3cdc58b1277b12366424a176fe23
so .get_attr has to beed used in order to remain compatible with
pyroute2 >= 0.5.15.

Calling extend on a list with None as argument waill raise a TypeError.
This happens when no peers are added yet (e.g. after a fresh boot)