### PR TITLE
README additions & build fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,15 @@
-FROM gcr.io/cloud-marketplace-containers/google/bazel:3.5.0 AS builder
+FROM python:3.10-bullseye AS builder
+
+RUN apt-get update && apt-get install -y apt-transport-https curl gnupg \
+    && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >/usr/share/keyrings/bazel-archive-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
+    && apt-get update && apt-get install -y bazel \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /wgkex
 
-COPY . ./
+COPY BUILD WORKSPACE requirements.txt ./
+COPY wgkex ./wgkex
 
 RUN ["bazel", "build", "//wgkex/broker:app"]
 RUN ["bazel", "build", "//wgkex/worker:app"]

--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ For further information, please see this [presentation on the architecture](http
 The `wgkex` configuration file defaults to `/etc/wgkex.yaml` ([Sample configuration file](wgkex.yaml.example)), however
 can also be overwritten by setting the environment variable `WGKEX_CONFIG_FILE`.
 
-## Running the broker
+## Running the broker and worker
 
-* The worker can be started directly from a Git checkout:
+### Build using [Bazel](https://bazel.build)
+
+Worker:
 
 ```sh
 # defaults to /etc/wgkex.yaml if not set
@@ -86,7 +88,7 @@ bazel build //wgkex/worker:app
 ./bazel-bin/wgkex/worker/app
 ```
 
-* The broker can also be built and run via [bazel](https://bazel.build):
+Broker:
 
 ```sh
 # defaults to /etc/wgkex.yaml if not set
@@ -94,6 +96,21 @@ export WGKEX_CONFIG_FILE=/opt/wgkex/wgkex.yaml
 bazel build //wgkex/broker:app
 # Artifact will now be placed into ./bazel-bin/wgkex/broker/app
 ./bazel-bin/wgkex/broker/app
+```
+
+### Run using Python
+
+Broker:
+(Using Flask development server)
+
+```sh
+FLASK_ENV=development FLASK_DEBUG=1 FLASK_APP=wgkex/broker/app.py python3 -m flask run
+```
+
+Worker:
+
+```sh
+python3 -c 'from wgkex.worker.app import main; main()'
 ```
 
 ## Client usage

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,8 +2,9 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_python",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.1.0/rules_python-0.1.0.tar.gz",
-    sha256 = "b6d46438523a3ec0f3cead544190ee13223a52f6a6765a29eae7b7cc24cc83a0",
+    sha256 = "a3a6e99f497be089f81ec082882e40246bfd435f52f4e82f37e89449b04573f6",
+    strip_prefix = "rules_python-0.10.2",
+    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.10.2.tar.gz",
 )
 
 # PIP support.


### PR DESCRIPTION
This splits the first chunk from #87, these changes are mostly unrelated with #87.

## Changes
* Some fixes and additions for the README
* Update `rules_python` in `WORKSPACE` to fix building with up to date Bazel releases, in particularly this error:
  ```
  $ bazelisk build //wgkex/broker:app
  ERROR: ~/.cache/bazel/_bazel_user/0cb50d472ede3feaa890df93c18ed4c0/external/pip/pypi__flask/BUILD:5:11:
  no such package '@pip//pypi__importlib_metadata':
  BUILD file not found in directory 'pypi__importlib_metadata' of external repository @pip.
  Add a BUILD file to a directory to mark it as a package. and referenced by '@pip//pypi__flask:pypi__flask'
  ```
* Unfortunately, this breaks building with the old Bazel version frmo the Docker image (from 2020).
  The upstream Docker image is [dead](https://github.com/bazelbuild/continuous-integration/issues/1060), so now we build our own from the python base image.