### PR TITLE
Add broker listen config to wgkex.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The frontend broker exposes the following API endpoints for use:
 /api/v1/wg/key/exchange
 ```
 
+The listen address and port for the Flask server can be configured in `wgkex.yaml` under the `broker_listen` key:
+
+```yaml
+broker_listen:
+  # host defaults to 127.0.0.1 if unspecified
+  host: 0.0.0.0
+  # port defaults to 5000 if unspecified
+  port: 5000
+```
+
 #### POST /api/v1/wg/key/exchange
 
 JSON POST'd to this endpoint should be in this format:

--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -18,6 +18,9 @@ mqtt:
   password: SECRET
   keepalive: 5
   tls: False
+broker_listen:
+  host: 0.0.0.0
+  port: 5000
 domain_prefix: myprefix-
 logging_config:
     formatters:

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -160,4 +160,12 @@ def is_valid_domain(domain: str) -> str:
 
 
 if __name__ == "__main__":
-    app.run()
+    listen_host = None
+    listen_port = None
+
+    listen_config = config.fetch_from_config("broker_listen")
+    if listen_config is not None:
+        listen_host = listen_config.get("host")
+        listen_port = listen_config.get("port")
+
+    app.run(host=listen_host, port=listen_port)


### PR DESCRIPTION
## Problem
We have troubles running the broker from the current main image, since we need the broker to listen on 0.0.0.0 in the Docker container to expose the port.
This is currently not configurable, and setting `FLASK_RUN_HOST` in the Dockerfile or docker-compose.yml doesn't work either, probably because we don't use `flask run` to start the server.

## Changes
A new _optional_ section `broker_listen` with the subkeys `host` and `port` is added to wgkex.yaml`.
They are passed to Flask if specified, otherwise the Flask defaults are kept.

Tested locally and in an earlier version on docker04.