### PR TITLE
Use waitress instead of flask for prod

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ flask-mqtt
 pyroute2
 PyYAML
 Flask
+waitress
 
 # Common
 ipaddress

--- a/wgkex/broker/BUILD
+++ b/wgkex/broker/BUILD
@@ -9,6 +9,7 @@ py_binary(
     deps=[
         requirement("flask"),
         requirement("flask-mqtt"),
+        requirement("waitress"),
         "//wgkex/config:config",
     ],
 )

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -13,6 +13,7 @@ from flask.app import Flask as Flask_app
 from flask_mqtt import Mqtt
 import paho.mqtt.client as mqtt_client
 
+from waitress import serve
 from wgkex.config import config
 from wgkex.common import logger
 
@@ -168,4 +169,4 @@ if __name__ == "__main__":
         listen_host = listen_config.get("host")
         listen_port = listen_config.get("port")
 
-    app.run(host=listen_host, port=listen_port)
+    serve(app, host=listen_host, port=listen_port)


### PR DESCRIPTION
This replaces the Flask development env with an actual server called `waitess`.

See here:
https://docs.pylonsproject.org/projects/waitress/en/latest/arguments.html