### PR TITLE
Disable keepalive on Gateway site

### DIFF
--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -11,7 +11,6 @@ import pyroute2
 from wgkex.common.utils import mac2eui64
 from wgkex.common import logger
 
-_PERSISTENT_KEEPALIVE_SECONDS = 15
 _PEER_TIMEOUT_HOURS = 3
 
 
@@ -149,7 +148,6 @@ def update_wireguard_peer(client: WireGuardClient) -> Dict:
     with pyroute2.WireGuard() as wg:
         wg_peer = {
             "public_key": client.public_key,
-            "persistent_keepalive": _PERSISTENT_KEEPALIVE_SECONDS,
             "allowed_ips": [client.lladdr],
             "remove": client.remove,
         }

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -89,7 +89,6 @@ class NetlinkTest(unittest.TestCase):
             "wg-add",
             peer={
                 "public_key": "public_key",
-                "persistent_keepalive": 15,
                 "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
                 "remove": False,
             },

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -147,7 +147,6 @@ class NetlinkTest(unittest.TestCase):
             "wg-add",
             peer={
                 "public_key": "public_key",
-                "persistent_keepalive": 15,
                 "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
                 "remove": False,
             },


### PR DESCRIPTION
This will safe us some CPU cycles and the Clients can keep on doing it.