### PR TITLE
Some fixes for the loadbalancing changes

### DIFF
--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -1,4 +1,4 @@
-# [broker] The domains that should be accepted by clients and for which matching WireGuard interfaces exist
+# [broker, worker] The domains that should be accepted by clients and for which matching WireGuard interfaces exist
 domains:
   - ffmuc_muc_cty
   - ffmuc_muc_nord

--- a/wgkex/worker/app_test.py
+++ b/wgkex/worker/app_test.py
@@ -90,7 +90,7 @@ class AppTest(unittest.TestCase):
             app.main()
         connect_mock.assert_not_called()
 
-    @mock.patch.object(app, "_CLEANUP_TIME", 0)
+    @mock.patch.object(app, "_CLEANUP_TIME", 1)
     @mock.patch.object(app, "wg_flush_stale_peers")
     def test_flush_workers_doesnt_throw(self, wg_flush_mock):
         """Ensure the flush_workers thread doesn't throw and exit if it encounters an exception."""

--- a/wgkex/worker/mqtt.py
+++ b/wgkex/worker/mqtt.py
@@ -127,6 +127,7 @@ def on_connect(client: mqtt.Client, userdata: Any, flags, rc) -> None:
         logger.info(f"Subscribing to topic {topic}")
         client.subscribe(topic)
 
+    for domain in domains:
         # Publish worker data (WG pubkeys, ports, local addresses)
         iface = wg_interface_name(domain)
         if iface:


### PR DESCRIPTION
Some bugs I noticed while trying out #87 on a gateway:

- [worker] Use pyroute2.IPRoute instead of .NDB to get wg link address, as NDB() takes 20 seconds to instantiate
- [worker] Fix get_connected_peers_coun() for peers without handshake time
- [broker] Use total_peers count to correctly calculate diff to expected peers
- [broker] Don't update worker status on MQTT messages if it hasn't actually changed (mostly to reduce log spam)