### PR TITLE
Pin and downgrade Bazel to fix build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11.8-bookworm AS builder
 RUN apt-get update && apt-get install -y apt-transport-https curl gnupg \
     && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >/usr/share/keyrings/bazel-archive-keyring.gpg \
     && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
-    && apt-get update && apt-get install -y bazel \
+    && apt-get update && apt-get install -y bazel-7.0.2 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /wgkex
@@ -11,15 +11,15 @@ WORKDIR /wgkex
 COPY BUILD WORKSPACE requirements.txt ./
 COPY wgkex ./wgkex
 
-RUN ["bazel", "build", "//wgkex/broker:app"]
-RUN ["bazel", "build", "//wgkex/worker:app"]
-RUN ["cp", "-rL", "bazel-bin", "bazel"]
+RUN ["bazel-7.0.2", "build", "//wgkex/broker:app"]
+RUN ["bazel-7.0.2", "build", "//wgkex/worker:app"]
+RUN ["cp", "-rL", "bazel-bin", "bazel-7.0.2"]
 
 
 FROM python:3.11.8-slim-bookworm
 WORKDIR /wgkex
 
-COPY --from=builder /wgkex/bazel /wgkex/
+COPY --from=builder /wgkex/bazel-7.0.2 /wgkex/
 
 COPY entrypoint /entrypoint
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7-bullseye AS builder
+FROM python:3.11.8-bookworm AS builder
 
 RUN apt-get update && apt-get install -y apt-transport-https curl gnupg \
     && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >/usr/share/keyrings/bazel-archive-keyring.gpg \
@@ -15,7 +15,8 @@ RUN ["bazel", "build", "//wgkex/broker:app"]
 RUN ["bazel", "build", "//wgkex/worker:app"]
 RUN ["cp", "-rL", "bazel-bin", "bazel"]
 
-FROM python:3.11.7-bullseye
+
+FROM python:3.11.8-slim-bookworm
 WORKDIR /wgkex
 
 COPY --from=builder /wgkex/bazel /wgkex/


### PR DESCRIPTION
Version 7.1.0 runs into issues with its sandbox:
```
2.108 ERROR: Failed to initialize sandbox:
/root/.cache/bazel/_bazel_root/20f0ced2adfccd482c7c7a0094d96fba/sandbox/_moved_trash_dir
-> /root/.cache/bazel/_bazel_root/20f0ced2adfccd482c7c7a0094d96fba/sandbox/stale-trash-0
(Invalid cross-device link)
```