### PR TITLE
pin Bazel version

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,0 +1,2 @@
+7.4.1
+# make sure that the image in the Dockerfile and this version are identical

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gcr.io/bazel-public/bazel:7.4.1 AS builder
+# Make sure .bazelversion and the version of image are identical
 
 WORKDIR /wgkex
 


### PR DESCRIPTION
With the release of 8.0.0 our CI broke because we didn't pin the Bazel version