### PR TITLE
Potential fix for code scanning alert no. 18: Information exposure through an exception

### DIFF
--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -90,7 +90,8 @@ def wg_api_v1_key_exchange() -> Tuple[Response | Dict, int]:
     try:
         data = KeyExchange.from_dict(request.get_json(force=True))
     except Exception as ex:
-        return {"error": {"message": str(ex)}}, 400
+        logger.error(f"Exception occurred in /api/v1/wg/key/exchange: {ex}", exc_info=True)
+        return {"error": {"message": "An internal error has occurred. Please try again later."}}, 400
 
     key = data.public_key
     domain = data.domain
@@ -112,7 +113,8 @@ def wg_api_v2_key_exchange() -> Tuple[Response | Dict, int]:
     try:
         data = KeyExchange.from_dict(request.get_json(force=True))
     except Exception as ex:
-        return {"error": {"message": str(ex)}}, 400
+        logger.error(f"Exception occurred in /api/v2/wg/key/exchange: {ex}", exc_info=True)
+        return {"error": {"message": "An internal error has occurred. Please try again later."}}, 400
 
     key = data.public_key
     domain = data.domain


### PR DESCRIPTION
Potential fix for [https://github.com/freifunkMUC/wgkex/security/code-scanning/18](https://github.com/freifunkMUC/wgkex/security/code-scanning/18)

To fix the issue, we will replace the detailed error message in the response with a generic error message. The stack trace or exception details will be logged on the server for debugging purposes, but they will not be exposed to the user. This ensures that sensitive information is not leaked while still allowing developers to diagnose issues using server logs.

The changes will involve:
1. Logging the exception details using the `logger` module.
2. Returning a generic error message to the user instead of the exception details.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
