### PR TITLE
Fix Parker audit findings

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,2 +1,2 @@
-8.5.0
+9.0.0
 # make sure that the image in the Dockerfile and this version are identical

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,6 @@ RUN git clone --single-branch --branch release https://github.com/netbox-communi
 
 RUN apt-get update && \
     apt-get install -yq --no-install-recommends \
-    wireguard-go \
     wireguard-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -7,7 +7,12 @@
 - `/root/.cache/pip` and `/var/lib/docker` are volumes, for caching between restarts
 - NetBox instance auto-starts on port 8000 (forwarded)
 - MQTT service started automatically
-- `wg-welt` and `wg-nodes` interfaces created on startup (TODO: generate LL IPv6 address based on pubkey)
+- Kernel `wg-welt` and `wg-nodes` interfaces created on startup
+
+The worker manages WireGuard through generic netlink, so the devcontainer requires
+host kernel WireGuard support and the `NET_ADMIN` capability. Container startup fails
+with a clear error when kernel interfaces cannot be created; userspace `wireguard-go`
+interfaces are intentionally not used because the worker cannot manage them.
 
 ## NetBox (for Parker)
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,6 +15,9 @@ services:
       - pip-cache:/root/.cache/pip
       - docker-cache:/var/lib/docker
 
+    cap_add:
+      - NET_ADMIN
+
     # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
     # cap_add:
     #   - SYS_PTRACE

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -16,8 +16,15 @@ interface_linklocal() {
 sysctl -w net.ipv6.conf.all.addr_gen_mode=1
 
 for iface in wg-nodes wg-welt; do
-    # TODO userspace WireGuard can't be accessed using netlink by worker
-    wireguard-go $iface
+    if ip link show dev "$iface" >/dev/null 2>&1; then
+        if ! ip -details link show dev "$iface" | grep -qw wireguard; then
+            echo "Existing interface $iface is not a kernel WireGuard interface; the wgkex worker cannot manage it through generic netlink." >&2
+            exit 1
+        fi
+    elif ! ip link add dev "$iface" type wireguard; then
+        echo "Kernel WireGuard is unavailable. The wgkex worker requires host kernel WireGuard support and NET_ADMIN; userspace wireguard-go interfaces are not supported." >&2
+        exit 1
+    fi
     wg genkey | wg set $iface private-key /dev/stdin
     addr=$(interface_linklocal $(wg show $iface public-key))
     ip addr add $addr dev $iface

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -26,7 +26,7 @@ jobs:
           curl -L https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz| tar xvz
           cd "${GITHUB_WORKSPACE}"
           bazel coverage --combined_report=lcov --java_runtime_version=remotejdk_11 -t- --instrument_test_targets \
-            --test_output=errors --linkopt=--coverage --linkopt=-lc \
+            --test_output=errors --linkopt=--coverage --linkopt=-lc --instrumentation_filter=//wgkex \
             --test_env=PYTHON_COVERAGE=${GITHUB_WORKSPACE}/src/coverage-7.13.5/__main__.py \
             --test_verbose_timeout_warnings --define=config_file=test ...:all
       - name: Coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/bazel-public/bazel:8.5.0 AS builder
+FROM gcr.io/bazel-public/bazel:9.0.0 AS builder
 # Make sure .bazelversion and the version of image are identical
 
 WORKDIR /wgkex

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "rules_python", version = "1.0.0-rc2")
+bazel_dep(name = "rules_python", version = "1.7.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 18,
+  "lockFileVersion": 26,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -9,15 +9,32 @@
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
     "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
     "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
-    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.2/MODULE.bazel": "73939767a4686cd9a520d16af5ab440071ed75cec1a876bf2fcfaf1f71987a16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250127.1/MODULE.bazel": "c4a89e7ceb9bf1e25cf84a9f830ff6b817b72874088bf5141b314726e46a57c1",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250512.1/MODULE.bazel": "d209fdb6f36ffaf61c509fcc81b19e81b411a999a934a032e10cd009a0226215",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/MODULE.bazel": "51f2312901470cdab0dbdf3b88c40cd21c62a7ed58a3de45b365ddc5b11bcab2",
+    "https://bcr.bazel.build/modules/abseil-cpp/20250814.1/source.json": "cea3901d7e299da7320700abbaafe57a65d039f10d0d7ea601c4a66938ea4b0c",
+    "https://bcr.bazel.build/modules/apple_support/1.11.1/MODULE.bazel": "1843d7cd8a58369a444fc6000e7304425fba600ff641592161d9f15b179fb896",
+    "https://bcr.bazel.build/modules/apple_support/1.15.1/MODULE.bazel": "a0556fefca0b1bb2de8567b8827518f94db6a6e7e7d632b4c48dc5f865bc7c85",
+    "https://bcr.bazel.build/modules/apple_support/1.21.0/MODULE.bazel": "ac1824ed5edf17dee2fdd4927ada30c9f8c3b520be1b5fd02a5da15bc10bff3e",
+    "https://bcr.bazel.build/modules/apple_support/1.21.1/MODULE.bazel": "5809fa3efab15d1f3c3c635af6974044bac8a4919c62238cce06acee8a8c11f1",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/MODULE.bazel": "0e62471818affb9f0b26f128831d5c40b074d32e6dda5a0d3852847215a41ca4",
+    "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
+    "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
     "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
     "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
     "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
     "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
     "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
-    "https://bcr.bazel.build/modules/bazel_features/1.21.0/source.json": "3e8379efaaef53ce35b7b8ba419df829315a880cb0a030e5bb45c96d6d5ecb5f",
+    "https://bcr.bazel.build/modules/bazel_features/1.23.0/MODULE.bazel": "fd1ac84bc4e97a5a0816b7fd7d4d4f6d837b0047cf4cbd81652d616af3a6591a",
+    "https://bcr.bazel.build/modules/bazel_features/1.27.0/MODULE.bazel": "621eeee06c4458a9121d1f104efb80f39d34deff4984e778359c60eaf1a8cb65",
+    "https://bcr.bazel.build/modules/bazel_features/1.28.0/MODULE.bazel": "4b4200e6cbf8fa335b2c3f43e1d6ef3e240319c33d43d60cc0fbd4b87ece299d",
+    "https://bcr.bazel.build/modules/bazel_features/1.3.0/MODULE.bazel": "cdcafe83ec318cda34e02948e81d790aab8df7a929cec6f6969f13a489ccecd9",
+    "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
+    "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
+    "https://bcr.bazel.build/modules/bazel_features/1.33.0/source.json": "13617db3930328c2cd2807a0f13d52ca870ac05f96db9668655113265147b2a6",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
@@ -31,75 +48,93 @@
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
     "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
-    "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
-    "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.1/MODULE.bazel": "88ade7293becda963e0e3ea33e7d54d3425127e0a326e0d17da085a5f1f03ff6",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/MODULE.bazel": "69ad6927098316848b34a9142bcc975e018ba27f08c4ff403f50c1b6e646ca67",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.8.2/source.json": "34a3c8bcf233b835eb74be9d628899bb32999d3e0eadef1947a0a562a2b16ffb",
+    "https://bcr.bazel.build/modules/buildozer/8.2.1/MODULE.bazel": "61e9433c574c2bd9519cad7fa66b9c1d2b8e8d5f3ae5d6528a2c2d26e68d874d",
+    "https://bcr.bazel.build/modules/buildozer/8.2.1/source.json": "7c33f6a26ee0216f85544b4bca5e9044579e0219b6898dd653f5fb449cf2e484",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
-    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
     "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/googletest/1.15.2/MODULE.bazel": "6de1edc1d26cafb0ea1a6ab3f4d4192d91a312fd2d360b63adaa213cd00b2108",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/MODULE.bazel": "dbec758171594a705933a29fcf69293d2468c49ec1f2ebca65c36f504d72df46",
+    "https://bcr.bazel.build/modules/googletest/1.17.0/source.json": "38e4454b25fc30f15439c0378e57909ab1fd0a443158aa35aec685da727cd713",
     "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
-    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/MODULE.bazel": "2f8d20d3b7d54143213c4dfc3d98225c42de7d666011528dc8fe91591e2e17b0",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.6/source.json": "a04756d367a2126c3541682864ecec52f92cdee80a35735a3cb249ce015ca000",
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/MODULE.bazel": "6f7b417dcc794d9add9e556673ad25cb3ba835224290f4f848f8e2db1e1fca74",
+    "https://bcr.bazel.build/modules/nlohmann_json/3.6.1/source.json": "f448c6e8963fdfa7eb831457df83ad63d3d6355018f6574fb017e8169deb43a9",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
-    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
+    "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
-    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
-    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
-    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
+    "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
+    "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
+    "https://bcr.bazel.build/modules/protobuf/33.4/source.json": "555f8686b4c7d6b5ba731fbea13bf656b4bfd9a7ff629c1d9d3f6e1d6155de79",
     "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
-    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/MODULE.bazel": "e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.12.0/source.json": "6900fdc8a9e95866b8c0d4ad4aba4d4236317b5c1cd04c502df3f0d33afed680",
     "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
-    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/MODULE.bazel": "b4963dda9b31080be1905ef085ecd7dd6cd47c05c79b9cdf83ade83ab2ab271a",
+    "https://bcr.bazel.build/modules/re2/2024-07-02.bcr.1/source.json": "2ff292be6ef3340325ce8a045ecc326e92cbfab47c7cbab4bd85d28971b97ac4",
+    "https://bcr.bazel.build/modules/re2/2024-07-02/MODULE.bazel": "0eadc4395959969297cbcf31a249ff457f2f1d456228c67719480205aa306daa",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
     "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
+    "https://bcr.bazel.build/modules/rules_apple/3.16.0/MODULE.bazel": "0d1caf0b8375942ce98ea944be754a18874041e4e0459401d925577624d3a54a",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/MODULE.bazel": "76e10fd4a48038d3fc7c5dc6e63b7063bbf5304a2e3bd42edda6ec660eebea68",
+    "https://bcr.bazel.build/modules/rules_apple/4.1.0/source.json": "8ee81e1708756f81b343a5eb2b2f0b953f1d25c4ab3d4a68dc02754872e80715",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
     "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
     "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
     "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
     "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
     "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
     "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.1/MODULE.bazel": "2f0222a6f229f0bf44cd711dc13c858dad98c62d52bd51d8fc3a764a83125513",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.2/MODULE.bazel": "557ddc3a96858ec0d465a87c0a931054d7dcfd6583af2c7ed3baf494407fd8d0",
+    "https://bcr.bazel.build/modules/rules_cc/0.1.5/MODULE.bazel": "88dfc9361e8b5ae1008ac38f7cdfd45ad738e4fa676a3ad67d19204f045a1fd8",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.0/MODULE.bazel": "b5c17f90458caae90d2ccd114c81970062946f49f355610ed89bebf954f5783c",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.13/MODULE.bazel": "eecdd666eda6be16a8d9dc15e44b5c75133405e820f620a234acc4b1fdc5aa37",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.14/MODULE.bazel": "353c99ed148887ee89c54a17d4100ae7e7e436593d104b668476019023b58df8",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.14/source.json": "55d0a4587c5592fad350f6e698530f4faf0e7dd15e69d43f8d87e220c78bea54",
+    "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
-    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
-    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
-    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
     "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
     "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
     "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
-    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/MODULE.bazel": "c3d280bc5ff1038dcb3bacb95d3f6b83da8dd27bba57820ec89ea4085da767ad",
-    "https://bcr.bazel.build/modules/rules_java/8.11.0/source.json": "302b52a39259a85aa06ca3addb9787864ca3e03b432a5f964ea68244397e7544",
     "https://bcr.bazel.build/modules/rules_java/8.3.2/MODULE.bazel": "7336d5511ad5af0b8615fdc7477535a2e4e723a357b6713af439fe8cf0195017",
     "https://bcr.bazel.build/modules/rules_java/8.5.1/MODULE.bazel": "d8a9e38cc5228881f7055a6079f6f7821a073df3744d441978e7a43e20226939",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/9.0.3/MODULE.bazel": "1f98ed015f7e744a745e0df6e898a7c5e83562d6b759dfd475c76456dda5ccea",
+    "https://bcr.bazel.build/modules/rules_java/9.0.3/source.json": "b038c0c07e12e658135bbc32cc1a2ded6e33785105c9d41958014c592de4593e",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
     "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
-    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
     "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
-    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
-    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/MODULE.bazel": "e717beabc4d091ecb2c803c2d341b88590e9116b8bf7947915eeb33aab4f96dd",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.7/source.json": "5426f412d0a7fc6b611643376c7e4a82dec991491b9ce5cb1cfdd25fe2e92be4",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
     "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
@@ -111,58 +146,76 @@
     "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
-    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
-    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
+    "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
     "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
     "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
     "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
     "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
+    "https://bcr.bazel.build/modules/rules_python/0.33.2/MODULE.bazel": "3e036c4ad8d804a4dad897d333d8dce200d943df4827cb849840055be8d2e937",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
-    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
-    "https://bcr.bazel.build/modules/rules_python/1.0.0-rc2/MODULE.bazel": "7e755005ffab33a24df8af746781ee3d0ba2afad1617d97aaaf81a0a287e2a22",
-    "https://bcr.bazel.build/modules/rules_python/1.0.0-rc2/source.json": "0e7ded29166858fcf92c13efa358327943bc5008720dfd7c39f9630ddbb4516d",
+    "https://bcr.bazel.build/modules/rules_python/1.3.0/MODULE.bazel": "8361d57eafb67c09b75bf4bbe6be360e1b8f4f18118ab48037f2bd50aa2ccb13",
+    "https://bcr.bazel.build/modules/rules_python/1.4.1/MODULE.bazel": "8991ad45bdc25018301d6b7e1d3626afc3c8af8aaf4bc04f23d0b99c938b73a6",
+    "https://bcr.bazel.build/modules/rules_python/1.6.0/MODULE.bazel": "7e04ad8f8d5bea40451cf80b1bd8262552aa73f841415d20db96b7241bd027d8",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/MODULE.bazel": "d01f995ecd137abf30238ad9ce97f8fc3ac57289c8b24bd0bf53324d937a14f8",
+    "https://bcr.bazel.build/modules/rules_python/1.7.0/source.json": "028a084b65dcf8f4dc4f82f8778dbe65df133f234b316828a82e060d81bdce32",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
-    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/MODULE.bazel": "72e76b0eea4e81611ef5452aa82b3da34caca0c8b7b5c0c9584338aa93bae26b",
+    "https://bcr.bazel.build/modules/rules_shell/0.6.1/source.json": "20ec05cd5e592055e214b2da8ccb283c7f2a421ea0dc2acbf1aa792e11c03d0c",
+    "https://bcr.bazel.build/modules/rules_swift/1.16.0/MODULE.bazel": "4a09f199545a60d09895e8281362b1ff3bb08bbde69c6fc87aff5b92fcc916ca",
+    "https://bcr.bazel.build/modules/rules_swift/2.1.1/MODULE.bazel": "494900a80f944fc7aa61500c2073d9729dff0b764f0e89b824eb746959bc1046",
+    "https://bcr.bazel.build/modules/rules_swift/2.4.0/MODULE.bazel": "1639617eb1ede28d774d967a738b4a68b0accb40650beadb57c21846beab5efd",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/MODULE.bazel": "72c8f5cf9d26427cee6c76c8e3853eb46ce6b0412a081b2b6db6e8ad56267400",
+    "https://bcr.bazel.build/modules/rules_swift/3.1.2/source.json": "e85761f3098a6faf40b8187695e3de6d97944e98abd0d8ce579cb2daf6319a66",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
-    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
     "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
-    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/MODULE.bazel": "fc152419aa2ea0f51c29583fab1e8c99ddefd5b3778421845606ee628629e0e5",
     "https://bcr.bazel.build/modules/stardoc/0.7.2/source.json": "58b029e5e901d6802967754adf0a9056747e8176f017cfe3607c0851f4d42216",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.1/MODULE.bazel": "5e463fbfba7b1701d957555ed45097d7f984211330106ccd1352c6e0af0dcf91",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/MODULE.bazel": "75aab2373a4bbe2a1260b9bf2a1ebbdbf872d3bd36f80bff058dccd82e89422f",
+    "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
-    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@platforms//host:extension.bzl%host_platform": {
+    "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "SeQiIN/f8/Qt9vYQk7qcXp4I4wJeEC0RnQDiaaJ4tb8=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "bzlTransitiveDigest": "06cynZ1bCvvy8zHPrrDlXq+Z68xmjctHpfFxi+zEpJY=",
+        "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
+        "recordedInputs": [
+          "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
+          "FILE:@@pybind11_bazel+//MODULE.bazel e6f4c20442eaa7c90d7190d8dc539d0ab422f95c65a57cc59562170c58ae3d34"
+        ],
         "generatedRepoSpecs": {
-          "host_platform": {
-            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
-            "attributes": {}
+          "pybind11": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@pybind11_bazel+//:pybind11-BUILD.bazel",
+              "strip_prefix": "pybind11-2.12.0",
+              "urls": [
+                "https://github.com/pybind/pybind11/archive/v2.12.0.zip"
+              ]
+            }
           }
-        },
-        "recordedRepoMappingEntries": []
+        }
       }
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "bzlTransitiveDigest": "ABI1D/sbS1ovwaW/kHDoj8nnXjQ0oKU9fzmzEG4iT8o=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
+        "recordedInputs": [
+          "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
+        ],
         "generatedRepoSpecs": {
           "com_github_jetbrains_kotlin_git": {
             "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
@@ -210,15 +263,207 @@
               ]
             }
           }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_kotlin+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
+        }
+      }
+    },
+    "@@rules_python+//python/extensions:config.bzl%config": {
+      "general": {
+        "bzlTransitiveDigest": "2hLgIvNVTLgxus0ZuXtleBe70intCfo0cHs8qvt6cdM=",
+        "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,pypi__build rules_python++config+pypi__build",
+          "REPO_MAPPING:rules_python+,pypi__click rules_python++config+pypi__click",
+          "REPO_MAPPING:rules_python+,pypi__colorama rules_python++config+pypi__colorama",
+          "REPO_MAPPING:rules_python+,pypi__importlib_metadata rules_python++config+pypi__importlib_metadata",
+          "REPO_MAPPING:rules_python+,pypi__installer rules_python++config+pypi__installer",
+          "REPO_MAPPING:rules_python+,pypi__more_itertools rules_python++config+pypi__more_itertools",
+          "REPO_MAPPING:rules_python+,pypi__packaging rules_python++config+pypi__packaging",
+          "REPO_MAPPING:rules_python+,pypi__pep517 rules_python++config+pypi__pep517",
+          "REPO_MAPPING:rules_python+,pypi__pip rules_python++config+pypi__pip",
+          "REPO_MAPPING:rules_python+,pypi__pip_tools rules_python++config+pypi__pip_tools",
+          "REPO_MAPPING:rules_python+,pypi__pyproject_hooks rules_python++config+pypi__pyproject_hooks",
+          "REPO_MAPPING:rules_python+,pypi__setuptools rules_python++config+pypi__setuptools",
+          "REPO_MAPPING:rules_python+,pypi__tomli rules_python++config+pypi__tomli",
+          "REPO_MAPPING:rules_python+,pypi__wheel rules_python++config+pypi__wheel",
+          "REPO_MAPPING:rules_python+,pypi__zipp rules_python++config+pypi__zipp"
+        ],
+        "generatedRepoSpecs": {
+          "rules_python_internal": {
+            "repoRuleId": "@@rules_python+//python/private:internal_config_repo.bzl%internal_config_repo",
+            "attributes": {
+              "transition_setting_generators": {},
+              "transition_settings": []
+            }
+          },
+          "pypi__build": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e2/03/f3c8ba0a6b6e30d7d18c40faab90807c9bb5e9a1e3b2fe2008af624a9c97/build-1.2.1-py3-none-any.whl",
+              "sha256": "75e10f767a433d9a86e50d83f418e83efc18ede923ee5ff7df93b6cb0306c5d4",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__click": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl",
+              "sha256": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__colorama": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+              "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__importlib_metadata": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/2d/0a/679461c511447ffaf176567d5c496d1de27cbe34a87df6677d7171b2fbd4/importlib_metadata-7.1.0-py3-none-any.whl",
+              "sha256": "30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__installer": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/e5/ca/1172b6638d52f2d6caa2dd262ec4c811ba59eee96d54a7701930726bce18/installer-0.7.0-py3-none-any.whl",
+              "sha256": "05d1933f0a5ba7d8d6296bb6d5018e7c94fa473ceb10cf198a92ccea19c27b53",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__more_itertools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/50/e2/8e10e465ee3987bb7c9ab69efb91d867d93959095f4807db102d07995d94/more_itertools-10.2.0-py3-none-any.whl",
+              "sha256": "686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__packaging": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl",
+              "sha256": "2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pep517": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/25/6e/ca4a5434eb0e502210f591b97537d322546e4833dcb4d470a48c375c5540/pep517-0.13.1-py3-none-any.whl",
+              "sha256": "31b206f67165b3536dd577c5c3f1518e8fbaf38cbc57efff8369a392feff1721",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/8a/6a/19e9fe04fca059ccf770861c7d5721ab4c2aebc539889e97c7977528a53b/pip-24.0-py3-none-any.whl",
+              "sha256": "ba0d021a166865d2265246961bec0152ff124de910c5cc39f1156ce3fa7c69dc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pip_tools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/0d/dc/38f4ce065e92c66f058ea7a368a9c5de4e702272b479c0992059f7693941/pip_tools-7.4.1-py3-none-any.whl",
+              "sha256": "4c690e5fbae2f21e87843e89c26191f0d9454f362d8acdbd695716493ec8b3a9",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__pyproject_hooks": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/ae/f3/431b9d5fe7d14af7a32340792ef43b8a714e7726f1d7b69cc4e8e7a3f1d7/pyproject_hooks-1.1.0-py3-none-any.whl",
+              "sha256": "7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__setuptools": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/90/99/158ad0609729111163fc1f674a5a42f2605371a4cf036d0441070e2f7455/setuptools-78.1.1-py3-none-any.whl",
+              "sha256": "c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__tomli": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl",
+              "sha256": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__wheel": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/7d/cd/d7460c9a869b16c3dd4e1e403cce337df165368c71d6af229a74699622ce/wheel-0.43.0-py3-none-any.whl",
+              "sha256": "55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          },
+          "pypi__zipp": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "url": "https://files.pythonhosted.org/packages/da/55/a03fd7240714916507e1fcf7ae355bd9d9ed2e6db492595f1a67f61681be/zipp-3.18.2-py3-none-any.whl",
+              "sha256": "dce197b859eb796242b0622af1b8beb0a722d52aa2f57133ead08edd5bf5374e",
+              "type": "zip",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nload(\"@rules_python//python:py_library.bzl\", \"py_library\")\n\npy_library(\n    name = \"lib\",\n    srcs = glob([\"**/*.py\"]),\n    data = glob([\"**/*\"], exclude=[\n        # These entries include those put into user-installed dependencies by\n        # data_exclude to avoid non-determinism.\n        \"**/*.py\",\n        \"**/*.pyc\",\n        \"**/*.pyc.*\",  # During pyc creation, temp files named *.pyc.NNN are created\n        \"**/*.dist-info/RECORD\",\n        \"BUILD\",\n        \"WORKSPACE\",\n    ]),\n    # This makes this directory a top-level in the python import\n    # search path for anything that depends on this.\n    imports = [\".\"],\n)\n"
+            }
+          }
+        }
+      }
+    },
+    "@@rules_python+//python/uv:uv.bzl%uv": {
+      "general": {
+        "bzlTransitiveDigest": "ijW9KS7qsIY+yBVvJ+Nr1mzwQox09j13DnE3iIwaeTM=",
+        "usagesDigest": "H8dQoNZcoqP+Mu0tHZTi4KHATzvNkM5ePuEqoQdklIU=",
+        "recordedInputs": [
+          "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
+          "REPO_MAPPING:rules_python+,platforms platforms"
+        ],
+        "generatedRepoSpecs": {
+          "uv": {
+            "repoRuleId": "@@rules_python+//python/uv/private:uv_toolchains_repo.bzl%uv_toolchains_repo",
+            "attributes": {
+              "toolchain_type": "'@@rules_python+//python/uv:uv_toolchain_type'",
+              "toolchain_names": [
+                "none"
+              ],
+              "toolchain_implementations": {
+                "none": "'@@rules_python+//python:none'"
+              },
+              "toolchain_compatible_with": {
+                "none": [
+                  "@platforms//:incompatible"
+                ]
+              },
+              "toolchain_target_settings": {}
+            }
+          }
+        }
       }
     }
-  }
+  },
+  "facts": {}
 }

--- a/wgkex/broker/BUILD
+++ b/wgkex/broker/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@pip//:requirements.bzl", "requirement")
 
 py_library(

--- a/wgkex/broker/BUILD
+++ b/wgkex/broker/BUILD
@@ -13,6 +13,20 @@ py_library(
 )
 
 py_test(
+    name="app_test",
+    srcs=["app_test.py"],
+    deps = [
+       "//wgkex/broker:app",
+       "//wgkex/broker:parker",
+       "//wgkex/config:config",
+       requirement("flask-mqtt"),
+       requirement("mock"),
+       requirement("paho-mqtt"),
+    ],
+    size="small",
+)
+
+py_test(
     name="ipam_json_test",
     srcs=["ipam_json_test.py"],
     deps = [
@@ -72,6 +86,16 @@ py_test(
        "//wgkex/config:config",
        requirement("mock"),
        requirement("paho-mqtt"),
+    ],
+    size="small",
+)
+
+py_test(
+    name="signer_test",
+    srcs=["signer_test.py"],
+    deps = [
+       "//wgkex/broker:signer",
+       "//wgkex/config:config",
     ],
     size="small",
 )

--- a/wgkex/broker/BUILD
+++ b/wgkex/broker/BUILD
@@ -13,6 +13,15 @@ py_library(
 )
 
 py_test(
+    name="ipam_json_test",
+    srcs=["ipam_json_test.py"],
+    deps = [
+       "//wgkex/broker:ipam",
+    ],
+    size="small",
+)
+
+py_test(
     name="ipam_netbox_test",
     srcs=["ipam_netbox_test.py"],
     deps = [
@@ -62,6 +71,19 @@ py_test(
        "//wgkex/config:config",
        requirement("mock"),
        requirement("paho-mqtt"),
+    ],
+    size="small",
+)
+
+py_test(
+    name="startup_test",
+    srcs=["startup_test.py"],
+    deps = [
+       "//wgkex/broker:app",
+       "//wgkex/broker:parker",
+       "//wgkex/config:config",
+       requirement("flask-mqtt"),
+       requirement("mock"),
     ],
     size="small",
 )

--- a/wgkex/broker/BUILD
+++ b/wgkex/broker/BUILD
@@ -68,6 +68,7 @@ py_test(
     deps = [
        "//wgkex/broker:app",
        "//wgkex/broker:parker",
+       "//wgkex/broker:signer",
        "//wgkex/config:config",
        requirement("mock"),
        requirement("paho-mqtt"),

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -74,12 +74,9 @@ def _fetch_app_config() -> Flask_app:
     app.config["MQTT_PASSWORD"] = mqtt_cfg.password
     app.config["MQTT_KEEPALIVE"] = mqtt_cfg.keepalive
     app.config["MQTT_TLS_ENABLED"] = mqtt_cfg.tls
-    # Configure a Last Will so other instances learn this broker went away
-    last_will_topic = (
-        MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE
-        if config.get_config().parker.enabled
-        else MQTTTopics.TOPIC_BROKER_ANNOUNCE
-    ).format(broker=_HOSTNAME)
+    # The retained legacy status is canonical in every mode so the single MQTT
+    # last will can reliably clear both legacy and Parker broker state.
+    last_will_topic = MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker=_HOSTNAME)
     app.config["MQTT_LAST_WILL_TOPIC"] = last_will_topic
     app.config["MQTT_LAST_WILL_MESSAGE"] = 0
     app.config["MQTT_LAST_WILL_QOS"] = 1
@@ -246,6 +243,7 @@ def wg_api_v2_key_exchange() -> Tuple[Response | Dict, int]:
 
 @app.route("/api/v3/wg/key/exchange", methods=["GET"])
 @app.route("/api/v3/config", methods=["GET"])
+@app.route("/config", methods=["GET"])
 def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
     if not config.get_config().parker.enabled or ipam is None:
         return {
@@ -291,6 +289,16 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
         return {
             "error": {
                 "message": "No IPv6 range available for this public key. Please try again later."
+            }
+        }, 500
+    if full_range6.prefixlen > 63:
+        logger.error(
+            "Allocated IPv6 range %s is too small for Parker's two /64 networks",
+            full_range6,
+        )
+        return {
+            "error": {
+                "message": "Allocated IPv6 range is invalid. Please try again later."
             }
         }, 500
     ranges = full_range6.subnets(new_prefix=64)
@@ -366,7 +374,9 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
             {
                 "address4": "10.0.0.1",  # TODO fetch real concentrator address4 from worker status
                 "address6": w_data.get("LinkAddress"),
-                "endpoint": f"{w_data.get('ExternalAddress')}:{str(w_data.get('Port'))}",
+                "endpoint": join_host_port(
+                    str(w_data.get("ExternalAddress")), str(w_data.get("Port"))
+                ),
                 "pubkey": w_data.get("PublicKey"),  # type: ignore
                 "id": worker.id,
             }
@@ -430,30 +440,39 @@ def handle_mqtt_connect(
             )
             return
 
+    mqtt.subscribe(MQTTTopics.TOPIC_CONNECTED_PEERS.format(worker="+", domain="+"))
+    mqtt.subscribe(MQTTTopics.TOPIC_WORKER_STATUS.format(worker="+"))
+    mqtt.subscribe(MQTTTopics.TOPIC_WORKER_WG_DATA.format(worker="+", domain="+"))
+    mqtt.subscribe(MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker="+"))
+    mqtt.publish(
+        MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker=_HOSTNAME),
+        1,  # pyright: ignore[reportArgumentType]
+        qos=1,
+        retain=True,
+    )
+
     if config.get_config().parker.enabled:
         logger.debug("Parker mode is enabled, subscribing to parker topics")
         mqtt.subscribe(MQTTTopics.TOPIC_PARKER_CONNECTED_PEERS.format(worker="+"))
         mqtt.subscribe(MQTTTopics.TOPIC_PARKER_WORKER_STATUS.format(worker="+"))
         mqtt.subscribe(MQTTTopics.TOPIC_PARKER_WORKER_WG_DATA.format(worker="+"))
         mqtt.subscribe(MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(broker="+"))
-        # Announce this broker as online
+        parker_announce_topic = MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(
+            broker=_HOSTNAME
+        )
+        # Clear retained Parker announcements from older versions. The retained
+        # legacy status and its last will are the canonical liveness source.
         mqtt.publish(
-            MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(broker=_HOSTNAME),
-            1,  # pyright: ignore[reportArgumentType]
+            parker_announce_topic,
+            b"",
             qos=1,
             retain=True,
         )
-    else:
-        mqtt.subscribe(MQTTTopics.TOPIC_CONNECTED_PEERS.format(worker="+", domain="+"))
-        mqtt.subscribe(MQTTTopics.TOPIC_WORKER_STATUS.format(worker="+"))
-        mqtt.subscribe(MQTTTopics.TOPIC_WORKER_WG_DATA.format(worker="+", domain="+"))
-        mqtt.subscribe(MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker="+"))
-        # Announce this broker as online
         mqtt.publish(
-            MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker=_HOSTNAME),
+            parker_announce_topic,
             1,  # pyright: ignore[reportArgumentType]
             qos=1,
-            retain=True,
+            retain=False,
         )
 
 
@@ -599,23 +618,23 @@ def handle_mqtt_message_broker_status(
                 f"Broker marked online: {broker}, {len(active_brokers) + 1} brokers online"
             )
         active_brokers.add(broker)
+        if config.get_config().parker.enabled:
+            parker_active_brokers.add(broker)
     else:
         if broker in active_brokers:
             logger.info(
                 f"Broker marked offline: {broker}, {len(active_brokers) - 1} brokers online"
             )
             active_brokers.discard(broker)
+        if config.get_config().parker.enabled:
+            parker_active_brokers.discard(broker)
 
 
 @mqtt.on_topic(MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(broker="+"))
 def handle_mqtt_message_parker_broker_status(
     client: mqtt_client.Client, userdata: bytes, message: mqtt_client.MQTTMessage
 ) -> None:
-    """Track online/offline brokers announced via MQTT.
-
-    Brokers should publish retained 1 when online and 0 when offline. LWT
-    causes retained 0 to be published on unexpected disconnect.
-    """
+    """Track Parker broker status aliases announced by compatible brokers."""
     logger.debug(
         f"Broker announce received on {message.topic}: {message.payload.decode()}"
     )
@@ -670,14 +689,23 @@ def _publish_offline_and_exit(signum, frame) -> None:
     """Publish retained offline announce and exit the process."""
     try:
         logger.info("Broker shutting down, announcing offline status")
-        announce_topic = (
-            MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(broker=_HOSTNAME)
-            if config.get_config().parker.enabled
-            else MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker=_HOSTNAME)
-        )
         mqtt.publish(
-            announce_topic, 0, qos=1, retain=True
-        )  # pyright: ignore[reportArgumentType]
+            MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker=_HOSTNAME),
+            0,  # pyright: ignore[reportArgumentType]
+            qos=1,
+            retain=True,
+        )
+        if config.get_config().parker.enabled:
+            parker_announce_topic = MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(
+                broker=_HOSTNAME
+            )
+            mqtt.publish(parker_announce_topic, b"", qos=1, retain=True)
+            mqtt.publish(
+                parker_announce_topic,
+                0,  # pyright: ignore[reportArgumentType]
+                qos=1,
+                retain=False,
+            )
         # Give the client loop a moment to send the message
         time.sleep(2)
     except Exception:

--- a/wgkex/broker/app_test.py
+++ b/wgkex/broker/app_test.py
@@ -1,0 +1,527 @@
+import importlib
+import ipaddress
+import json
+import sys
+import unittest
+
+import flask_mqtt
+import mock
+import paho.mqtt.client
+import paho.mqtt.enums
+
+from wgkex.config import config
+
+_DOMAIN = "_test_domain"
+_PUBLIC_KEY = "TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g="
+
+
+class MqttStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def init_app(self, app, **kwargs):
+        return None
+
+    def on_topic(self, topic=None):
+        return lambda func: func
+
+    def on_connect(self):
+        return lambda func: func
+
+    def on_message(self):
+        return lambda func: func
+
+    def subscribe(self, *args, **kwargs):
+        return None
+
+    def publish(self, *args, **kwargs):
+        return None
+
+
+def _test_config() -> config.Config:
+    return config.Config.from_dict(
+        {
+            "domains": [_DOMAIN],
+            "domain_prefixes": ["_test_"],
+            "mqtt": {"broker_url": "", "username": "", "password": ""},
+        }
+    )
+
+
+def _parker_config() -> config.Config:
+    return config.Config.from_dict(
+        {
+            "parker": {
+                "enabled": True,
+                "464xlat": True,
+                "ipam": "json",
+                "prefixes": {
+                    "ipv4": {"clat_subnet": "10.80.96.0/22"},
+                    "ipv6": {"length": 63},
+                },
+            },
+            "broker_signing_key": "signing-key",
+            "domains": [],
+            "domain_prefixes": [],
+            "workers": {},
+            "mqtt": {"broker_url": "", "username": "", "password": ""},
+        }
+    )
+
+
+def _message(topic: str, payload: bytes) -> paho.mqtt.client.MQTTMessage:
+    message = paho.mqtt.client.MQTTMessage()
+    message.topic = topic.encode()
+    message.payload = payload
+    return message
+
+
+class TestBrokerApp(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        config._parsed_config = _test_config()
+        with mock.patch.object(flask_mqtt, "Mqtt", MqttStub):
+            cls.broker_app = importlib.import_module("wgkex.broker.app")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        config._parsed_config = None
+        sys.modules.pop("wgkex.broker.app", None)
+        sys.modules.pop("wgkex.broker.signer", None)
+
+    def setUp(self) -> None:
+        config._parsed_config = _test_config()
+        self.broker_app.worker_data.clear()
+        self.broker_app.parker_worker_data.clear()
+        self.broker_app.active_brokers.clear()
+        self.broker_app.parker_active_brokers.clear()
+        self.broker_app.worker_metrics.data.clear()
+        self.broker_app.parker_worker_metrics.data.clear()
+
+    def test_index_and_v1_exchange_routes(self):
+        with mock.patch.object(
+            self.broker_app, "render_template", return_value="index"
+        ):
+            response = self.broker_app.app.test_client().get("/")
+        self.assertEqual(response.text, "index")
+
+        with mock.patch.object(self.broker_app, "mqtt") as mqtt:
+            response = self.broker_app.app.test_client().post(
+                "/api/v1/wg/key/exchange",
+                json={"public_key": _PUBLIC_KEY, "domain": _DOMAIN},
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json, {"Message": "OK"})
+        mqtt.publish.assert_called_once_with(f"wireguard/{_DOMAIN}/all", _PUBLIC_KEY)
+
+        response = self.broker_app.app.test_client().post(
+            "/api/v1/wg/key/exchange",
+            json={"public_key": "invalid", "domain": "unknown"},
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_v2_exchange_error_and_success_paths(self):
+        response = self.broker_app.app.test_client().post(
+            "/api/v2/wg/key/exchange",
+            json={"public_key": "invalid", "domain": _DOMAIN},
+        )
+        self.assertEqual(response.status_code, 400)
+
+        with mock.patch.object(
+            self.broker_app.worker_metrics,
+            "get_best_worker",
+            return_value=(None, 0, 0),
+        ):
+            response = self.broker_app.app.test_client().post(
+                "/api/v2/wg/key/exchange",
+                json={"public_key": _PUBLIC_KEY, "domain": _DOMAIN},
+            )
+        self.assertEqual(response.status_code, 400)
+
+        with mock.patch.object(
+            self.broker_app.worker_metrics,
+            "get_best_worker",
+            return_value=("worker", 0, 1),
+        ):
+            response = self.broker_app.app.test_client().post(
+                "/api/v2/wg/key/exchange",
+                json={"public_key": _PUBLIC_KEY, "domain": _DOMAIN},
+            )
+        self.assertEqual(response.status_code, 500)
+
+        self.broker_app.worker_data[("worker", _DOMAIN)] = {
+            "ExternalAddress": "gateway.example",
+            "Port": 51820,
+            "LinkAddress": "fe80::1",
+            "PublicKey": "gateway-key",
+        }
+        metrics = mock.MagicMock()
+        metrics.get_domain_metrics.return_value = {"connected_peers": 3}
+        self.broker_app.active_brokers.update({"broker-a", "broker-b"})
+        with (
+            mock.patch.object(
+                self.broker_app.worker_metrics,
+                "get_best_worker",
+                return_value=("worker", 0, 3),
+            ),
+            mock.patch.object(
+                self.broker_app.worker_metrics, "get", return_value=metrics
+            ),
+            mock.patch.object(self.broker_app.worker_metrics, "update") as update,
+        ):
+            response = self.broker_app.app.test_client().post(
+                "/api/v2/wg/key/exchange",
+                json={"public_key": _PUBLIC_KEY, "domain": _DOMAIN},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json["Endpoint"],
+            {
+                "Address": "gateway.example",
+                "Port": "51820",
+                "AllowedIPs": ["fe80::1"],
+                "PublicKey": "gateway-key",
+            },
+        )
+        update.assert_called_once_with("worker", _DOMAIN, "connected_peers", 5)
+
+    def test_load_parker_ipam_modes(self):
+        self.assertIsNone(self.broker_app._load_parker_ipam())
+
+        cfg = mock.MagicMock()
+        cfg.parker.enabled = True
+        cfg.parker.ipam = config.Parker.IPAM.JSON
+        with (
+            mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
+            mock.patch.object(
+                self.broker_app, "JSONFileIPAM", return_value="json-ipam"
+            ),
+        ):
+            self.assertEqual(self.broker_app._load_parker_ipam(), "json-ipam")
+
+        cfg.parker.ipam = config.Parker.IPAM.NETBOX
+        cfg.netbox = config.Netbox(url="https://netbox", api_key="token")
+        with (
+            mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
+            mock.patch.object(
+                self.broker_app, "NetboxIPAM", return_value="netbox-ipam"
+            ) as netbox,
+        ):
+            self.assertEqual(self.broker_app._load_parker_ipam(), "netbox-ipam")
+        netbox.assert_called_once_with(
+            api_url="https://netbox", token="token", xlat=True
+        )
+
+        cfg.netbox = None
+        with (
+            mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
+            self.assertRaisesRegex(Exception, "Missing config for NetBox"),
+        ):
+            self.broker_app._load_parker_ipam()
+
+        cfg.parker.ipam = "unsupported"
+        with (
+            mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
+            self.assertRaises(NotImplementedError),
+        ):
+            self.broker_app._load_parker_ipam()
+
+    def test_mqtt_connect_success_and_failure(self):
+        mqtt = mock.MagicMock()
+        client = mock.MagicMock(host="mqtt", port=1883)
+        with mock.patch.object(self.broker_app, "mqtt", mqtt):
+            self.broker_app.handle_mqtt_connect(
+                client, b"", {}, paho.mqtt.enums.ConnackCode.CONNACK_ACCEPTED
+            )
+        self.assertEqual(mqtt.subscribe.call_count, 4)
+        mqtt.publish.assert_called_once_with(mock.ANY, 1, qos=1, retain=True)
+
+        mqtt.reset_mock()
+        with mock.patch.object(self.broker_app, "mqtt", mqtt):
+            self.broker_app.handle_mqtt_connect(client, b"", {}, 1)
+        mqtt.subscribe.assert_not_called()
+        mqtt.publish.assert_not_called()
+
+    def test_worker_metric_status_and_data_handlers(self):
+        self.broker_app.handle_mqtt_message_metrics(
+            None,
+            b"",
+            _message(f"wireguard-metrics/{_DOMAIN}/worker/connected_peers", b"4"),
+        )
+        self.assertEqual(
+            self.broker_app.worker_metrics.get("worker")
+            .get_domain_metrics(_DOMAIN)
+            .get("connected_peers"),
+            4,
+        )
+        self.broker_app.handle_mqtt_message_metrics(
+            None,
+            b"",
+            _message("wireguard-metrics/unknown/worker/connected_peers", b"4"),
+        )
+        self.broker_app.handle_mqtt_message_metrics(
+            None,
+            b"",
+            _message(f"wireguard-metrics/{_DOMAIN}//connected_peers", b"4"),
+        )
+
+        online_metrics = mock.MagicMock()
+        online_metrics.is_online.return_value = True
+        with (
+            mock.patch.object(
+                self.broker_app.worker_metrics, "get", return_value=online_metrics
+            ),
+            mock.patch.object(self.broker_app.worker_metrics, "set_offline") as offline,
+        ):
+            self.broker_app.handle_mqtt_message_status(
+                None, b"", _message("wireguard-worker/worker/status", b"0")
+            )
+        offline.assert_called_once_with("worker")
+
+        offline_metrics = mock.MagicMock()
+        offline_metrics.is_online.return_value = False
+        with (
+            mock.patch.object(
+                self.broker_app.worker_metrics, "get", return_value=offline_metrics
+            ),
+            mock.patch.object(self.broker_app.worker_metrics, "set_online") as online,
+        ):
+            self.broker_app.handle_mqtt_message_status(
+                None, b"", _message("wireguard-worker/worker/status", b"1")
+            )
+        online.assert_called_once_with("worker")
+
+        self.broker_app.handle_mqtt_message_data(
+            None,
+            b"",
+            _message(
+                f"wireguard-worker/worker/{_DOMAIN}/data",
+                json.dumps({"Port": 51820}).encode(),
+            ),
+        )
+        self.assertEqual(
+            self.broker_app.worker_data[("worker", _DOMAIN)], {"Port": 51820}
+        )
+        self.broker_app.handle_mqtt_message_data(
+            None,
+            b"",
+            _message("wireguard-worker/worker/unknown/data", b"{}"),
+        )
+        self.broker_app.handle_mqtt_message_data(
+            None,
+            b"",
+            _message(f"wireguard-worker/worker/{_DOMAIN}/data", b"[]"),
+        )
+
+    def test_broker_status_and_fallback_handlers(self):
+        message = _message("wireguard-broker/broker/status", b"invalid")
+        self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
+        self.assertNotIn("broker", self.broker_app.active_brokers)
+
+        message.payload = b"1"
+        self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
+        self.assertIn("broker", self.broker_app.active_brokers)
+        message.payload = b"0"
+        self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
+        self.assertNotIn("broker", self.broker_app.active_brokers)
+
+        self.broker_app.handle_mqtt_message(
+            None, b"", _message("unhandled/topic", b"payload")
+        )
+
+    def test_non_parker_shutdown_uses_legacy_announcement(self):
+        with (
+            mock.patch.object(self.broker_app, "mqtt") as mqtt,
+            mock.patch.object(self.broker_app.time, "sleep") as sleep,
+            mock.patch.object(self.broker_app.sys, "exit") as exit_process,
+        ):
+            self.broker_app._publish_offline_and_exit(None, None)
+
+        mqtt.publish.assert_called_once_with(mock.ANY, 0, qos=1, retain=True)
+        sleep.assert_called_once_with(2)
+        exit_process.assert_called_once_with(0)
+
+    def test_parker_exchange_reports_query_and_ipam_failures(self):
+        cfg = _parker_config()
+        ipam = mock.MagicMock()
+        query = {"pubkey": _PUBLIC_KEY, "nonce": "nonce"}
+
+        with (
+            mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
+            mock.patch.object(self.broker_app, "ipam", ipam),
+        ):
+            response = self.broker_app.app.test_client().get(
+                "/config", query_string={"pubkey": "invalid"}
+            )
+            self.assertEqual(response.status_code, 400)
+
+            ipam.get_or_allocate_prefix.side_effect = RuntimeError("allocation failed")
+            response = self.broker_app.app.test_client().get(
+                "/config", query_string=query
+            )
+            self.assertEqual(response.status_code, 500)
+
+            ipam.get_or_allocate_prefix.side_effect = None
+            ipam.get_or_allocate_prefix.return_value = (None, None, [])
+            response = self.broker_app.app.test_client().get(
+                "/config", query_string=query
+            )
+            self.assertEqual(response.status_code, 500)
+
+    def test_parker_exchange_worker_fallback_and_error_paths(self):
+        cfg = _parker_config()
+        ipam = mock.MagicMock()
+        ipam.get_or_allocate_prefix.return_value = (
+            None,
+            ipaddress.IPv6Network("2001:db8:42::/63"),
+            [],
+        )
+        query = {"pubkey": _PUBLIC_KEY, "nonce": "nonce"}
+        worker = self.broker_app.WorkerResult(
+            name="worker", id=7, diff=0, peers=0, target=0
+        )
+
+        with (
+            mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
+            mock.patch.object(self.broker_app, "ipam", ipam),
+            mock.patch.object(
+                self.broker_app.parker_worker_metrics,
+                "get_best_workers",
+                return_value=[],
+            ),
+        ):
+            response = self.broker_app.app.test_client().get(
+                "/config", query_string=query
+            )
+            self.assertEqual(response.status_code, 400)
+
+            self.broker_app.parker_worker_data["worker"] = {
+                "LinkAddress": "fe80::1",
+                "ExternalAddress": "gateway.example",
+                "Port": 51820,
+                "PublicKey": "gateway-key",
+            }
+            with mock.patch.object(
+                self.broker_app, "sign_response", return_value=b"signature"
+            ):
+                response = self.broker_app.app.test_client().get(
+                    "/config", query_string=query
+                )
+            self.assertEqual(response.status_code, 200)
+            payload = json.loads(response.data.split(b"\n", 1)[0])
+            self.assertEqual(payload["concentrators"][0]["id"], 0)
+
+            self.broker_app.parker_worker_data.clear()
+            with mock.patch.object(
+                self.broker_app.parker_worker_metrics,
+                "get_best_workers",
+                return_value=[worker],
+            ):
+                response = self.broker_app.app.test_client().get(
+                    "/config", query_string=query
+                )
+            self.assertEqual(response.status_code, 500)
+
+            self.broker_app.parker_worker_data["worker"] = {
+                "LinkAddress": "fe80::1",
+                "ExternalAddress": "gateway.example",
+                "Port": 51820,
+                "PublicKey": "gateway-key",
+            }
+            cfg.broker_signing_key = None
+            with mock.patch.object(
+                self.broker_app.parker_worker_metrics,
+                "get_best_workers",
+                return_value=[worker],
+            ):
+                response = self.broker_app.app.test_client().get(
+                    "/config", query_string=query
+                )
+            self.assertEqual(response.status_code, 500)
+
+    def test_parker_metric_status_and_invalid_data_handlers(self):
+        self.broker_app.handle_mqtt_message_parker_metrics(
+            None,
+            b"",
+            _message("parker/wireguard-metrics//connected_peers", b"4"),
+        )
+        self.assertEqual(self.broker_app.parker_worker_metrics.data, {})
+        self.broker_app.handle_mqtt_message_parker_metrics(
+            None,
+            b"",
+            _message("parker/wireguard-metrics/worker/connected_peers", b"4"),
+        )
+        self.assertEqual(
+            self.broker_app.parker_worker_metrics.get("worker")
+            .get_domain_metrics("parker")
+            .get("connected_peers"),
+            4,
+        )
+
+        online_metrics = mock.MagicMock()
+        online_metrics.is_online.return_value = True
+        with (
+            mock.patch.object(
+                self.broker_app.parker_worker_metrics,
+                "get",
+                return_value=online_metrics,
+            ),
+            mock.patch.object(
+                self.broker_app.parker_worker_metrics, "set_offline"
+            ) as offline,
+        ):
+            self.broker_app.handle_mqtt_message_parker_status(
+                None,
+                b"",
+                _message("parker/wireguard-worker/worker/status", b"0"),
+            )
+        offline.assert_called_once_with("worker")
+
+        offline_metrics = mock.MagicMock()
+        offline_metrics.is_online.return_value = False
+        with (
+            mock.patch.object(
+                self.broker_app.parker_worker_metrics,
+                "get",
+                return_value=offline_metrics,
+            ),
+            mock.patch.object(
+                self.broker_app.parker_worker_metrics, "set_online"
+            ) as online,
+        ):
+            self.broker_app.handle_mqtt_message_parker_status(
+                None,
+                b"",
+                _message("parker/wireguard-worker/worker/status", b"1"),
+            )
+        online.assert_called_once_with("worker")
+
+        self.broker_app.handle_mqtt_message_parker_data(
+            None,
+            b"",
+            _message("parker/wireguard-worker/worker/data", b"[]"),
+        )
+        self.assertNotIn("worker", self.broker_app.parker_worker_data)
+
+        invalid_status = _message("parker/wireguard-broker/broker/status", b"invalid")
+        self.broker_app.handle_mqtt_message_parker_broker_status(
+            None, b"", invalid_status
+        )
+        self.assertNotIn("broker", self.broker_app.parker_active_brokers)
+
+    def test_shutdown_still_exits_when_publish_fails(self):
+        with (
+            mock.patch.object(
+                self.broker_app.mqtt,
+                "publish",
+                side_effect=RuntimeError("publish failed"),
+            ),
+            mock.patch.object(self.broker_app.sys, "exit") as exit_process,
+        ):
+            self.broker_app._publish_offline_and_exit(None, None)
+        exit_process.assert_called_once_with(0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wgkex/broker/ipam_json.py
+++ b/wgkex/broker/ipam_json.py
@@ -1,6 +1,9 @@
+import fcntl
 import ipaddress
 import json
 import os
+import stat
+import tempfile
 from typing import Dict, List, Optional, Tuple
 
 from wgkex.broker.ipam import ParkerIPAM
@@ -21,6 +24,9 @@ FILE_PATH = "/var/local/wgkex/broker/ipv6_ranges.json"
 
 
 class JSONFileIPAM(ParkerIPAM):
+    def __init__(self, file_path: str = FILE_PATH) -> None:
+        self.file_path = file_path
+
     def get_or_allocate_prefix(
         self,
         pubkey: str,
@@ -42,49 +48,95 @@ class JSONFileIPAM(ParkerIPAM):
         if not ipv6:
             return None, None, []
 
-        ranges: Dict[str, str] = {}
-        parent_prefix = ipaddress.IPv6Network(
-            "2001:db8:ed0::/56"
-        )  # Default parent prefix
+        storage_dir = os.path.dirname(self.file_path) or "."
+        os.makedirs(storage_dir, exist_ok=True)
+
+        with open(f"{self.file_path}.lock", "a+", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+            try:
+                ranges: Dict[str, str] = {}
+                parent_prefix = ipaddress.IPv6Network("2001:db8:ed0::/56")
+                try:
+                    with open(self.file_path, "r", encoding="utf-8") as ranges_file:
+                        json_content = json.load(ranges_file)
+                        ranges = json_content.get("ranges", {})
+                        parent_prefix = ipaddress.IPv6Network(
+                            json_content.get("parent_prefix", parent_prefix)
+                        )
+                except FileNotFoundError:
+                    pass
+                except json.JSONDecodeError as error:
+                    logger.error(
+                        "Could not decode JSON IPAM storage %s",
+                        self.file_path,
+                        exc_info=error,
+                    )
+                    raise
+
+                range6 = ranges.get(pubkey)
+                if range6 is None or not ipaddress.IPv6Network(range6).subnet_of(
+                    parent_prefix
+                ):
+                    parsed_ranges = [
+                        ipaddress.IPv6Network(stored_range)
+                        for stored_range in ranges.values()
+                        if ipaddress.IPv6Network(stored_range).subnet_of(parent_prefix)
+                    ]
+                    range6 = None
+
+                    prefixes = parent_prefix.subnets(new_prefix=ipv6_prefix_length)
+                    next(prefixes)  # Reserve the first prefix for infrastructure.
+                    for candidate in prefixes:
+                        if candidate not in parsed_ranges:
+                            range6 = str(candidate)
+                            break
+                    if range6 is None:
+                        logger.error(
+                            "No IPv6 range available for public key %s.", pubkey
+                        )
+                        return None, None, []
+
+                    logger.info(
+                        "No existing IPv6 range found for public key %s, assigning %s",
+                        pubkey,
+                        range6,
+                    )
+                    ranges[pubkey] = range6
+                    self._atomic_write(parent_prefix, ranges, storage_dir)
+
+                return None, ipaddress.IPv6Network(range6), []
+            finally:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+    def _atomic_write(
+        self,
+        parent_prefix: ipaddress.IPv6Network,
+        ranges: Dict[str, str],
+        storage_dir: str,
+    ) -> None:
+        existing_mode: Optional[int] = None
         try:
-            with open(FILE_PATH, "r", encoding="utf-8") as f:
-                json_content = json.load(f)
-                ranges = json_content.get("ranges", {})
-                parent_prefix = ipaddress.IPv6Network(
-                    json_content.get("parent_prefix", parent_prefix)
-                )
+            existing_mode = stat.S_IMODE(os.stat(self.file_path).st_mode)
         except FileNotFoundError:
-            os.makedirs("/var/local/wgkex/broker", exist_ok=True)
-        except json.JSONDecodeError:
             pass
 
-        range6 = ranges.get(pubkey, None)
-        if range6 is None or not ipaddress.IPv6Network(range6).subnet_of(parent_prefix):
-            parsed_ranges = [
-                ipaddress.IPv6Network(rg)
-                for rg in ranges.values()
-                if ipaddress.IPv6Network(rg).subnet_of(parent_prefix)
-            ]  # Filter out any ranges that are not subnets of the parent prefix
-
-            prefixes = parent_prefix.subnets(new_prefix=ipv6_prefix_length)
-            next(prefixes)  # skip first
-            for candidate in prefixes:
-                if candidate not in parsed_ranges:
-                    range6 = candidate
-                    break
-            if range6 is None:
-                logger.error(f"No IPv6 range available for public key {pubkey}.")
-                return None, None, []
-            else:
-                logger.info(
-                    f"No existing IPv6 range found for public key {pubkey}, assigning {range6}"
+        fd, temporary_path = tempfile.mkstemp(
+            dir=storage_dir, prefix=".ipv6_ranges.", text=True
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as ranges_file:
+                json.dump(
+                    {"parent_prefix": str(parent_prefix), "ranges": ranges},
+                    ranges_file,
                 )
-
-            ranges[pubkey] = str(range6)
-            with open(FILE_PATH, "w", encoding="utf-8") as f:
-                json.dump({"parent_prefix": str(parent_prefix), "ranges": ranges}, f)
-
-        return None, ipaddress.IPv6Network(range6), []
+                ranges_file.flush()
+                os.fsync(ranges_file.fileno())
+            if existing_mode is not None:
+                os.chmod(temporary_path, existing_mode)
+            os.replace(temporary_path, self.file_path)
+        finally:
+            if os.path.exists(temporary_path):
+                os.unlink(temporary_path)
 
     def release_prefix(self, pubkey: str) -> None:
         raise NotImplementedError

--- a/wgkex/broker/ipam_json_test.py
+++ b/wgkex/broker/ipam_json_test.py
@@ -1,0 +1,102 @@
+import json
+import multiprocessing
+import os
+import tempfile
+import unittest
+from typing import Any
+
+from wgkex.broker.ipam_json import JSONFileIPAM
+
+
+def _allocate_prefix(
+    storage_path: str,
+    pubkey: str,
+    start: Any,
+    results: Any,
+) -> None:
+    start.wait()
+    _, prefix, _ = JSONFileIPAM(storage_path).get_or_allocate_prefix(
+        pubkey, ipv4=False, ipv6=True, ipv6_prefix_length=63
+    )
+    results.put(str(prefix))
+
+
+class TestJSONFileIPAM(unittest.TestCase):
+    def test_atomic_storage_persists_and_reuses_allocations(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            ipam = JSONFileIPAM(storage_path)
+
+            _, first_prefix, _ = ipam.get_or_allocate_prefix(
+                "pubkey-a", ipv4=False, ipv6=True, ipv6_prefix_length=63
+            )
+            _, reused_prefix, _ = ipam.get_or_allocate_prefix(
+                "pubkey-a", ipv4=False, ipv6=True, ipv6_prefix_length=63
+            )
+            _, second_prefix, _ = ipam.get_or_allocate_prefix(
+                "pubkey-b", ipv4=False, ipv6=True, ipv6_prefix_length=63
+            )
+
+            self.assertEqual(first_prefix, reused_prefix)
+            self.assertNotEqual(first_prefix, second_prefix)
+            with open(storage_path, "r", encoding="utf-8") as ranges_file:
+                persisted = json.load(ranges_file)
+            self.assertEqual(
+                persisted["ranges"],
+                {
+                    "pubkey-a": str(first_prefix),
+                    "pubkey-b": str(second_prefix),
+                },
+            )
+
+    def test_invalid_json_is_reported_without_overwriting_storage(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            with open(storage_path, "w", encoding="utf-8") as ranges_file:
+                ranges_file.write("{invalid")
+
+            with self.assertRaises(json.JSONDecodeError):
+                JSONFileIPAM(storage_path).get_or_allocate_prefix(
+                    "pubkey", ipv4=False, ipv6=True, ipv6_prefix_length=63
+                )
+
+            with open(storage_path, "r", encoding="utf-8") as ranges_file:
+                self.assertEqual(ranges_file.read(), "{invalid")
+
+    def test_concurrent_processes_allocate_distinct_persistent_prefixes(self):
+        context = multiprocessing.get_context("fork")
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            with open(storage_path, "w", encoding="utf-8") as ranges_file:
+                json.dump(
+                    {"parent_prefix": "2001:db8:ed0::/56", "ranges": {}},
+                    ranges_file,
+                )
+
+            start = context.Event()
+            results = context.Queue()
+            processes = [
+                context.Process(
+                    target=_allocate_prefix,
+                    args=(storage_path, f"pubkey-{index}", start, results),
+                )
+                for index in range(8)
+            ]
+            for process in processes:
+                process.start()
+            start.set()
+            for process in processes:
+                process.join(timeout=10)
+                self.assertEqual(process.exitcode, 0)
+
+            allocated = [results.get(timeout=1) for _ in processes]
+            self.assertEqual(len(set(allocated)), len(processes))
+
+            with open(storage_path, "r", encoding="utf-8") as ranges_file:
+                persisted = json.load(ranges_file)
+            self.assertEqual(len(persisted["ranges"]), len(processes))
+            self.assertEqual(set(persisted["ranges"].values()), set(allocated))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wgkex/broker/ipam_json_test.py
+++ b/wgkex/broker/ipam_json_test.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 from typing import Any
+from unittest import mock
 
 from wgkex.broker.ipam_json import JSONFileIPAM
 
@@ -62,6 +63,52 @@ class TestJSONFileIPAM(unittest.TestCase):
 
             with open(storage_path, "r", encoding="utf-8") as ranges_file:
                 self.assertEqual(ranges_file.read(), "{invalid")
+
+    def test_exhausted_parent_prefix_returns_no_allocation(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            with open(storage_path, "w", encoding="utf-8") as ranges_file:
+                json.dump(
+                    {
+                        "parent_prefix": "2001:db8::/126",
+                        "ranges": {"existing": "2001:db8::2/127"},
+                    },
+                    ranges_file,
+                )
+
+            _, prefix, _ = JSONFileIPAM(storage_path).get_or_allocate_prefix(
+                "new-pubkey", ipv4=False, ipv6=True, ipv6_prefix_length=127
+            )
+
+            self.assertIsNone(prefix)
+            with open(storage_path, "r", encoding="utf-8") as ranges_file:
+                self.assertEqual(
+                    json.load(ranges_file)["ranges"],
+                    {"existing": "2001:db8::2/127"},
+                )
+
+    def test_atomic_replace_failure_removes_temporary_file(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            with (
+                mock.patch(
+                    "wgkex.broker.ipam_json.os.replace",
+                    side_effect=OSError("replace failed"),
+                ),
+                self.assertRaisesRegex(OSError, "replace failed"),
+            ):
+                JSONFileIPAM(storage_path).get_or_allocate_prefix(
+                    "pubkey", ipv4=False, ipv6=True, ipv6_prefix_length=63
+                )
+
+            self.assertEqual(
+                [
+                    name
+                    for name in os.listdir(temporary_dir)
+                    if name.startswith(".ipv6_ranges.")
+                ],
+                [],
+            )
 
     def test_concurrent_processes_allocate_distinct_persistent_prefixes(self):
         context = multiprocessing.get_context("fork")

--- a/wgkex/broker/ipam_netbox.py
+++ b/wgkex/broker/ipam_netbox.py
@@ -192,12 +192,6 @@ class NetboxIPAM(ParkerIPAM):
             prefix = self._deduplicate_prefixes(
                 pubkey, addr_family, allocated_prefix=res
             )
-            if prefix is None:
-                logger.error(
-                    "Allocated prefix for pubkey %s disappeared during reconciliation",
-                    pubkey,
-                )
-                return None, []
 
             desc = json.loads(prefix.description)
             stored_concentrators = desc.get("selected_concentrators", [])

--- a/wgkex/broker/ipam_netbox.py
+++ b/wgkex/broker/ipam_netbox.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from datetime import datetime, timezone
 from ipaddress import IPv4Network, IPv6Network
 from typing import Any, List, Optional, Tuple
@@ -51,12 +52,11 @@ class NetboxIPAM(ParkerIPAM):
 
             self.parent_prefix_v4 = next(prefixes_v4)
 
-    def _get_prefix(
+    def _get_prefixes(
         self,
         pubkey: str,
         addr_family: int,
-    ) -> Optional[pynetbox.models.ipam.Prefixes]:
-        # Look for existing prefixes first
+    ) -> List[pynetbox.models.ipam.Prefixes]:
         # https://netboxlabs.com/docs/netbox/reference/filtering/#string-fields
         candidate_prefixes = self.nb.ipam.prefixes.filter(
             family=addr_family,
@@ -64,6 +64,7 @@ class NetboxIPAM(ParkerIPAM):
             description__ic=pubkey,  # __ic: Contains (case-insensitive)
         )
 
+        matching_prefixes = []
         for candidate in candidate_prefixes:
             try:
                 desc = json.loads(candidate.description)
@@ -77,9 +78,52 @@ class NetboxIPAM(ParkerIPAM):
                 )
                 continue
             if desc.get("pubkey") == pubkey:
-                return candidate
+                matching_prefixes.append(candidate)
 
-        return None
+        return matching_prefixes
+
+    @staticmethod
+    def _prefix_sort_key(prefix: pynetbox.models.ipam.Prefixes) -> Tuple[int, str]:
+        prefix_id = getattr(prefix, "id", None)
+        return (
+            int(prefix_id) if prefix_id is not None else sys.maxsize,
+            str(prefix.prefix),
+        )
+
+    def _deduplicate_prefixes(
+        self,
+        pubkey: str,
+        addr_family: int,
+        allocated_prefix: Optional[pynetbox.models.ipam.Prefixes] = None,
+    ) -> Optional[pynetbox.models.ipam.Prefixes]:
+        candidates = self._get_prefixes(pubkey, addr_family)
+        if allocated_prefix is not None and not any(
+            getattr(candidate, "id", None) == getattr(allocated_prefix, "id", None)
+            for candidate in candidates
+        ):
+            candidates.append(allocated_prefix)
+        if not candidates:
+            return None
+
+        canonical = min(candidates, key=self._prefix_sort_key)
+        for duplicate in candidates:
+            if duplicate is canonical:
+                continue
+            try:
+                if not duplicate.delete():
+                    raise RuntimeError(
+                        f"NetBox refused to release duplicate prefix "
+                        f"{duplicate.prefix} for pubkey {pubkey}"
+                    )
+            except pynetbox.core.query.RequestError as error:
+                if getattr(getattr(error, "req", None), "status_code", None) == 404:
+                    continue
+                raise RuntimeError(
+                    f"Failed to release duplicate prefix {duplicate.prefix} "
+                    f"for pubkey {pubkey}"
+                ) from error
+
+        return canonical
 
     def _get_or_allocate_prefix(
         self,
@@ -91,7 +135,7 @@ class NetboxIPAM(ParkerIPAM):
         prefix: Optional[pynetbox.models.ipam.Prefixes] = None
         selected_concentrators: List[str] = []
 
-        prefix = self._get_prefix(pubkey, addr_family)
+        prefix = self._deduplicate_prefixes(pubkey, addr_family)
 
         if prefix is not None:
             desc = json.loads(prefix.description)
@@ -145,7 +189,20 @@ class NetboxIPAM(ParkerIPAM):
                     res,
                 )
                 return None, []
-            prefix = res
+            prefix = self._deduplicate_prefixes(
+                pubkey, addr_family, allocated_prefix=res
+            )
+            if prefix is None:
+                logger.error(
+                    "Allocated prefix for pubkey %s disappeared during reconciliation",
+                    pubkey,
+                )
+                return None, []
+
+            desc = json.loads(prefix.description)
+            stored_concentrators = desc.get("selected_concentrators", [])
+            if isinstance(stored_concentrators, list):
+                selected_concentrators = stored_concentrators
 
         return prefix, selected_concentrators
 
@@ -213,7 +270,7 @@ class NetboxIPAM(ParkerIPAM):
     def _update_prefix(
         self, pubkey: str, addr_family: int, selected_concentrators: List[str]
     ) -> None:
-        prefix = self._get_prefix(pubkey, addr_family)
+        prefix = self._deduplicate_prefixes(pubkey, addr_family)
 
         if prefix is not None:
             desc = json.loads(prefix.description)

--- a/wgkex/broker/ipam_netbox_test.py
+++ b/wgkex/broker/ipam_netbox_test.py
@@ -1,6 +1,9 @@
 import ipaddress
+import json
 import mock
+import threading
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 
 from wgkex.broker.ipam_netbox import NetboxIPAM
 from wgkex.config import config
@@ -51,6 +54,8 @@ def _mocked_netbox_response(*args, **kwargs):
                 status_code=200,
                 json_data={
                     "count": 1,
+                    "next": None,
+                    "previous": None,
                     "results": [
                         {
                             "id": 1,
@@ -70,6 +75,8 @@ def _mocked_netbox_response(*args, **kwargs):
                 status_code=200,
                 json_data={
                     "count": 1,
+                    "next": None,
+                    "previous": None,
                     "results": [
                         {
                             "id": 2,
@@ -140,6 +147,104 @@ class TestNetboxIPAM(unittest.TestCase):
             params=mock.ANY,
             json=mock.ANY,
         )
+
+    def test_concurrent_same_pubkey_allocations_converge_and_release_duplicate(self):
+        class FakePrefix:
+            def __init__(self, backend, prefix_id, prefix):
+                self.backend = backend
+                self.id = prefix_id
+                self.prefix = prefix
+                self.description = json.dumps(
+                    {
+                        "pubkey": "race-pubkey",
+                        "selected_concentrators": ["worker-a"],
+                    }
+                )
+
+            def delete(self):
+                with self.backend.lock:
+                    if self in self.backend.prefixes:
+                        self.backend.prefixes.remove(self)
+                return True
+
+        class SharedBackend:
+            def __init__(self):
+                self.lock = threading.Lock()
+                self.initial_lookup = threading.Barrier(2)
+                self.allocations = threading.Barrier(2)
+                self.prefixes = []
+                self.lookup_count = 0
+
+            def filter(self, **kwargs):
+                with self.lock:
+                    self.lookup_count += 1
+                    lookup_number = self.lookup_count
+                if lookup_number <= 2:
+                    self.initial_lookup.wait(timeout=5)
+                    return []
+                with self.lock:
+                    return list(self.prefixes)
+
+            def create(self, data):
+                with self.lock:
+                    prefix_id = len(self.prefixes) + 10
+                    prefix = FakePrefix(
+                        self,
+                        prefix_id,
+                        f"2001:db8:99:{(prefix_id - 10) * 2:x}::/63",
+                    )
+                    self.prefixes.append(prefix)
+                self.allocations.wait(timeout=5)
+                return prefix
+
+        backend = SharedBackend()
+
+        def make_ipam():
+            ipam = object.__new__(NetboxIPAM)
+            ipam.parent_prefix_v6 = mock.MagicMock(prefix="2001:db8:99::/48")
+            ipam.parent_prefix_v6.available_prefixes.create = backend.create
+            ipam.nb = mock.MagicMock()
+            ipam.nb.ipam.prefixes.filter = backend.filter
+            return ipam
+
+        def allocate(ipam):
+            return ipam._get_or_allocate_prefix("race-pubkey", 6, 63, None)
+
+        with (
+            mock.patch(
+                "wgkex.broker.ipam_netbox.pynetbox.models.ipam.Prefixes", FakePrefix
+            ),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            results = list(executor.map(allocate, [make_ipam(), make_ipam()]))
+
+        self.assertEqual([result[0].id for result in results], [10, 10])
+        self.assertEqual(
+            [result[1] for result in results],
+            [["worker-a"], ["worker-a"]],
+        )
+        self.assertEqual([prefix.id for prefix in backend.prefixes], [10])
+
+    def test_duplicate_release_failure_does_not_report_convergence(self):
+        canonical = mock.MagicMock(
+            id=10,
+            prefix="2001:db8:99::/63",
+            description='{"pubkey": "pubkey"}',
+        )
+        duplicate = mock.MagicMock(
+            id=11,
+            prefix="2001:db8:99:2::/63",
+            description='{"pubkey": "pubkey"}',
+        )
+        duplicate.delete.return_value = False
+
+        with mock.patch.object(
+            self.ipam,
+            "_get_prefixes",
+            return_value=[canonical, duplicate],
+        ):
+            with self.assertRaises(RuntimeError):
+                self.ipam._deduplicate_prefixes("pubkey", 6)
 
 
 if __name__ == "__main__":

--- a/wgkex/broker/ipam_netbox_test.py
+++ b/wgkex/broker/ipam_netbox_test.py
@@ -246,6 +246,76 @@ class TestNetboxIPAM(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 self.ipam._deduplicate_prefixes("pubkey", 6)
 
+    def test_allocated_prefix_is_kept_when_requery_visibility_is_delayed(self):
+        allocated = mock.MagicMock(
+            id=10,
+            prefix="2001:db8:99::/63",
+            description='{"pubkey": "pubkey"}',
+        )
+
+        with mock.patch.object(self.ipam, "_get_prefixes", return_value=[]):
+            canonical = self.ipam._deduplicate_prefixes(
+                "pubkey", 6, allocated_prefix=allocated
+            )
+
+        self.assertIs(canonical, allocated)
+        allocated.delete.assert_not_called()
+
+    def test_concurrent_duplicate_delete_404_is_already_reconciled(self):
+        class FakeRequestError(Exception):
+            def __init__(self):
+                self.req = mock.MagicMock(status_code=404)
+
+        canonical = mock.MagicMock(
+            id=10,
+            prefix="2001:db8:99::/63",
+            description='{"pubkey": "pubkey"}',
+        )
+        duplicate = mock.MagicMock(
+            id=11,
+            prefix="2001:db8:99:2::/63",
+            description='{"pubkey": "pubkey"}',
+        )
+        duplicate.delete.side_effect = FakeRequestError()
+
+        with (
+            mock.patch.object(
+                self.ipam,
+                "_get_prefixes",
+                return_value=[canonical, duplicate],
+            ),
+            mock.patch(
+                "wgkex.broker.ipam_netbox.pynetbox.core.query.RequestError",
+                FakeRequestError,
+            ),
+        ):
+            reconciled = self.ipam._deduplicate_prefixes("pubkey", 6)
+
+        self.assertIs(reconciled, canonical)
+
+    def test_duplicate_delete_server_error_fails_reconciliation(self):
+        class FakeRequestError(Exception):
+            def __init__(self):
+                self.req = mock.MagicMock(status_code=500)
+
+        canonical = mock.MagicMock(id=10, prefix="2001:db8:99::/63")
+        duplicate = mock.MagicMock(id=11, prefix="2001:db8:99:2::/63")
+        duplicate.delete.side_effect = FakeRequestError()
+
+        with (
+            mock.patch.object(
+                self.ipam,
+                "_get_prefixes",
+                return_value=[canonical, duplicate],
+            ),
+            mock.patch(
+                "wgkex.broker.ipam_netbox.pynetbox.core.query.RequestError",
+                FakeRequestError,
+            ),
+            self.assertRaisesRegex(RuntimeError, "Failed to release duplicate prefix"),
+        ):
+            self.ipam._deduplicate_prefixes("pubkey", 6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wgkex/broker/ipam_netbox_test.py
+++ b/wgkex/broker/ipam_netbox_test.py
@@ -1,6 +1,7 @@
 import ipaddress
 import json
 import mock
+import sys
 import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
@@ -315,6 +316,163 @@ class TestNetboxIPAM(unittest.TestCase):
             self.assertRaisesRegex(RuntimeError, "Failed to release duplicate prefix"),
         ):
             self.ipam._deduplicate_prefixes("pubkey", 6)
+
+    def test_constructor_validates_parent_prefixes(self):
+        def records(*items):
+            result = mock.MagicMock()
+            result.__len__.return_value = len(items)
+            result.__next__.side_effect = iter(items)
+            return result
+
+        cfg = mock.MagicMock()
+        cfg.parker.prefixes.ipv6.netbox_filter = {}
+        cfg.parker.prefixes.ipv4.netbox_filter = None
+        nb = mock.MagicMock()
+
+        with (
+            mock.patch("wgkex.broker.ipam_netbox.config.get_config", return_value=cfg),
+            mock.patch("wgkex.broker.ipam_netbox.pynetbox.api", return_value=nb),
+        ):
+            nb.ipam.prefixes.filter.return_value = records()
+            with self.assertRaisesRegex(ValueError, "parent IPv6 prefix"):
+                NetboxIPAM("https://netbox", "token")
+
+            parent_v6 = mock.MagicMock(prefix="2001:db8::/48")
+            nb.ipam.prefixes.filter.return_value = records(parent_v6)
+            with self.assertRaisesRegex(ValueError, "no IPv4 NetBox filter"):
+                NetboxIPAM("https://netbox", "token")
+
+            cfg.parker.prefixes.ipv4.netbox_filter = {"role": "wgkex"}
+            nb.ipam.prefixes.filter.side_effect = [
+                records(parent_v6),
+                records(),
+            ]
+            with self.assertRaisesRegex(ValueError, "parent IPv4 prefix"):
+                NetboxIPAM("https://netbox", "token")
+
+            parent_v4 = mock.MagicMock(prefix="10.0.0.0/8")
+            nb.ipam.prefixes.filter.side_effect = [
+                records(parent_v6),
+                records(parent_v4),
+            ]
+            ipam = NetboxIPAM("https://netbox", "token")
+            self.assertIs(ipam.parent_prefix_v4, parent_v4)
+
+    def test_prefix_lookup_ignores_malformed_descriptions(self):
+        ipam = object.__new__(NetboxIPAM)
+        ipam.parent_prefix_v6 = mock.MagicMock(prefix="2001:db8::/48")
+        ipam.nb = mock.MagicMock()
+        invalid_json = mock.MagicMock(prefix="2001:db8::/63", description="{")
+        non_object = mock.MagicMock(prefix="2001:db8:0:2::/63", description="[]")
+        wrong_key = mock.MagicMock(
+            prefix="2001:db8:0:4::/63",
+            description='{"pubkey": "someone-else"}',
+        )
+        match = mock.MagicMock(
+            prefix="2001:db8:0:6::/63",
+            description='{"pubkey": "pubkey"}',
+        )
+        ipam.nb.ipam.prefixes.filter.return_value = [
+            invalid_json,
+            non_object,
+            wrong_key,
+            match,
+        ]
+        self.assertEqual(ipam._get_prefixes("pubkey", 6), [match])
+        no_id = mock.MagicMock(spec=["prefix"])
+        no_id.prefix = "2001:db8::/63"
+        self.assertEqual(
+            self.ipam._prefix_sort_key(no_id),
+            (sys.maxsize, "2001:db8::/63"),
+        )
+
+    def test_existing_prefix_invalid_concentrators_are_ignored(self):
+        prefix = mock.MagicMock(
+            prefix="2001:db8::/63",
+            description='{"pubkey":"pubkey","selected_concentrators":"worker"}',
+        )
+        with mock.patch.object(self.ipam, "_deduplicate_prefixes", return_value=prefix):
+            returned, workers = self.ipam._get_or_allocate_prefix("pubkey", 6, 63, None)
+        self.assertIs(returned, prefix)
+        self.assertEqual(workers, [])
+
+    def test_allocation_failures_return_no_prefix(self):
+        class FakeRequestError(Exception):
+            pass
+
+        parent = mock.MagicMock()
+        ipam = object.__new__(NetboxIPAM)
+        ipam.parent_prefix_v6 = parent
+        with (
+            mock.patch.object(ipam, "_deduplicate_prefixes", return_value=None),
+            mock.patch(
+                "wgkex.broker.ipam_netbox.pynetbox.core.query.RequestError",
+                FakeRequestError,
+            ),
+        ):
+            parent.available_prefixes.create.side_effect = FakeRequestError()
+            self.assertEqual(
+                ipam._get_or_allocate_prefix("pubkey", 6, 63, None),
+                (None, []),
+            )
+
+            parent.available_prefixes.create.side_effect = None
+            parent.available_prefixes.create.return_value = {"prefix": "invalid"}
+            self.assertEqual(
+                ipam._get_or_allocate_prefix("pubkey", 6, 63, None),
+                (None, []),
+            )
+
+    def test_dual_stack_prefers_ipv6_concentrators(self):
+        ipam = object.__new__(NetboxIPAM)
+        ipam.xlat = False
+        ipam.parent_prefix_v4 = mock.MagicMock()
+        prefix6 = mock.MagicMock(prefix="2001:db8::/63")
+        prefix4 = mock.MagicMock(prefix="10.0.0.0/22")
+        ipam._get_or_allocate_prefix = mock.MagicMock(
+            side_effect=[
+                (prefix6, ["worker-v6"]),
+                (prefix4, ["worker-v4"]),
+            ]
+        )
+
+        prefix4_result, prefix6_result, workers = ipam.get_or_allocate_prefix(
+            "pubkey", ipv4=True, ipv6=True
+        )
+        self.assertEqual(prefix4_result, ipaddress.IPv4Network("10.0.0.0/22"))
+        self.assertEqual(prefix6_result, ipaddress.IPv6Network("2001:db8::/63"))
+        self.assertEqual(workers, ["worker-v6"])
+
+        ipam._get_or_allocate_prefix.side_effect = [
+            (None, []),
+            (prefix4, ["worker-v4"]),
+        ]
+        _, _, workers = ipam.get_or_allocate_prefix("pubkey", ipv4=True, ipv6=True)
+        self.assertEqual(workers, ["worker-v4"])
+
+    def test_update_prefix_handles_save_failure_and_both_families(self):
+        prefix = mock.MagicMock(
+            prefix="2001:db8::/63",
+            description='{"pubkey":"pubkey"}',
+        )
+        prefix.save.side_effect = RuntimeError("save failed")
+        with mock.patch.object(self.ipam, "_deduplicate_prefixes", return_value=prefix):
+            self.ipam._update_prefix("pubkey", 6, ["worker"])
+        self.assertEqual(
+            json.loads(prefix.description)["selected_concentrators"], ["worker"]
+        )
+
+        with mock.patch.object(self.ipam, "_update_prefix") as update:
+            self.ipam.update_prefix("pubkey", True, True, ["worker"])
+        update.assert_has_calls(
+            [
+                mock.call("pubkey", 4, ["worker"]),
+                mock.call("pubkey", 6, ["worker"]),
+            ]
+        )
+
+        with self.assertRaises(NotImplementedError):
+            self.ipam.release_prefix("pubkey")
 
 
 if __name__ == "__main__":

--- a/wgkex/broker/metrics_test.py
+++ b/wgkex/broker/metrics_test.py
@@ -167,6 +167,43 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].name, "2")
 
+    @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
+    def test_overloaded_sticky_worker_is_replaced(self, config_mock):
+        test_config = mock.MagicMock(spec=config.Config)
+        test_config.workers = config.Workers.from_dict(
+            {
+                "overloaded": {"id": 1, "weight": 50, "pop": "a"},
+                "available": {"id": 2, "weight": 50, "pop": "a"},
+                "other-pop": {"id": 3, "weight": 50, "pop": "b"},
+                "offline": {"id": 4, "weight": 50, "pop": "a"},
+            },
+            25,
+        )
+        config_mock.return_value = test_config
+
+        worker_metrics = WorkerMetricsCollection()
+        worker_metrics.update("overloaded", "d", "connected_peers", 100)
+        worker_metrics.update("available", "d", "connected_peers", 0)
+        worker_metrics.update("other-pop", "d", "connected_peers", 0)
+        worker_metrics.update("offline", "d", "connected_peers", 0)
+        worker_metrics.set_online("overloaded")
+        worker_metrics.set_online("available")
+        worker_metrics.set_online("other-pop")
+
+        results = worker_metrics.get_best_workers(
+            "d", current_selected_workers=["overloaded"]
+        )
+        self.assertCountEqual(
+            [result.name for result in results], ["available", "other-pop"]
+        )
+
+    def test_collection_set_and_total_skip_missing_record(self):
+        worker_metrics = WorkerMetricsCollection()
+        metrics = worker_metrics.get("worker")
+        worker_metrics.set("worker", metrics)
+        worker_metrics.data["missing"] = None
+        self.assertEqual(worker_metrics.get_total_peer_count(), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wgkex/broker/parker.py
+++ b/wgkex/broker/parker.py
@@ -86,7 +86,24 @@ class ParkerResponse:
     range6: str
     address6: str
     xlat_range6: str
-    range4: str = config.get_config().parker.prefixes.ipv4.clat_subnet
-    address4: str = str(ipaddress.IPv4Network(range4).network_address + 1)
-    wg_keepalive: int = config.get_config().parker.wg_keepalive
-    retry: int = config.get_config().parker.retry_interval
+    range4: str = dataclasses.field(
+        default_factory=lambda: (
+            config.get_config().parker.prefixes.ipv4.clat_subnet
+            or _missing_clat_subnet()
+        )
+    )
+    address4: str = ""
+    wg_keepalive: int = dataclasses.field(
+        default_factory=lambda: config.get_config().parker.wg_keepalive
+    )
+    retry: int = dataclasses.field(
+        default_factory=lambda: config.get_config().parker.retry_interval
+    )
+
+    def __post_init__(self) -> None:
+        if not self.address4:
+            self.address4 = str(ipaddress.IPv4Network(self.range4).network_address + 1)
+
+
+def _missing_clat_subnet() -> str:
+    raise ValueError("Parker 464XLAT requires an IPv4 CLAT subnet")

--- a/wgkex/broker/parker_test.py
+++ b/wgkex/broker/parker_test.py
@@ -65,6 +65,31 @@ class TestParkerQuery(unittest.TestCase):
         with self.assertRaises(ValueError):
             ParkerQuery.from_dict(data)
 
+    def test_parker_response_requires_clat_subnet_at_construction(self):
+        from wgkex.broker.parker import ParkerResponse
+
+        disabled_config = config.Config.from_dict(
+            {
+                "domains": [],
+                "domain_prefixes": [],
+                "mqtt": {"broker_url": "", "username": "", "password": ""},
+            }
+        )
+        with (
+            mock.patch.object(config, "get_config", return_value=disabled_config),
+            self.assertRaisesRegex(ValueError, "requires an IPv4 CLAT subnet"),
+        ):
+            ParkerResponse(
+                nonce="nonce",
+                time=0,
+                id="pubkey",
+                mtu=1280,
+                concentrators=[],
+                range6="2001:db8::/64",
+                address6="2001:db8::1",
+                xlat_range6="2001:db8:1::/64",
+            )
+
 
 class TestParker(unittest.TestCase):
     @classmethod
@@ -283,6 +308,33 @@ class TestParker(unittest.TestCase):
         broker_app.handle_mqtt_message_broker_status(None, None, msg)
         self.assertNotIn("broker1", broker_app.active_brokers)
         self.assertNotIn("broker1", broker_app.parker_active_brokers)
+
+    def test_parker_shutdown_clears_legacy_and_alias_status(self):
+        from wgkex.broker import app as broker_app
+        from wgkex.common.mqtt import MQTTTopics
+
+        legacy_topic = MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(
+            broker=broker_app._HOSTNAME
+        )
+        parker_topic = MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(
+            broker=broker_app._HOSTNAME
+        )
+        with (
+            mock.patch.object(broker_app, "mqtt") as mqtt,
+            mock.patch.object(broker_app.time, "sleep") as sleep,
+            mock.patch.object(broker_app.sys, "exit") as exit_process,
+        ):
+            broker_app._publish_offline_and_exit(None, None)
+
+        mqtt.publish.assert_has_calls(
+            [
+                mock.call(legacy_topic, 0, qos=1, retain=True),
+                mock.call(parker_topic, b"", qos=1, retain=True),
+                mock.call(parker_topic, 0, qos=1, retain=False),
+            ]
+        )
+        sleep.assert_called_once_with(2)
+        exit_process.assert_called_once_with(0)
 
     def test_get_active_brokers_count(self):
         from wgkex.broker import app as broker_app

--- a/wgkex/broker/parker_test.py
+++ b/wgkex/broker/parker_test.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import mock
 import sys
@@ -124,7 +125,121 @@ class TestParker(unittest.TestCase):
 
         # Test join_host_port
         self.assertEqual(broker_app.join_host_port("1.2.3.4", "51820"), "1.2.3.4:51820")
+        self.assertEqual(
+            broker_app.join_host_port("worker.example", "51820"),
+            "worker.example:51820",
+        )
         self.assertEqual(broker_app.join_host_port("::1", "51820"), "[::1]:51820")
+
+    def test_config_route_formats_ipv6_endpoint(self):
+        from wgkex.broker import app as broker_app
+        from wgkex.broker.metrics import WorkerResult
+
+        ipam = mock.MagicMock()
+        ipam.get_or_allocate_prefix.return_value = (
+            None,
+            ipaddress.IPv6Network("2001:db8:42::/63"),
+            ["worker1"],
+        )
+        worker = WorkerResult(name="worker1", id=1, diff=0, peers=0, target=0)
+        broker_app.parker_worker_data["worker1"] = {
+            "LinkAddress": "fe80::1",
+            "ExternalAddress": "2001:db8::1",
+            "Port": 51820,
+            "PublicKey": "worker-key",
+        }
+
+        query = {
+            "pubkey": "TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=",
+            "nonce": "nonce",
+        }
+        for route in ("/config", "/api/v3/config", "/api/v3/wg/key/exchange"):
+            with (
+                self.subTest(route=route),
+                mock.patch.object(broker_app, "ipam", ipam),
+                mock.patch.object(
+                    broker_app.parker_worker_metrics,
+                    "get_best_workers",
+                    return_value=[worker],
+                ),
+                mock.patch.object(
+                    broker_app, "sign_response", return_value=b"signature"
+                ),
+            ):
+                response = broker_app.app.test_client().get(route, query_string=query)
+
+            self.assertEqual(response.status_code, 200)
+            payload = json.loads(response.data.split(b"\n", 1)[0])
+            self.assertEqual(
+                payload["concentrators"][0]["endpoint"], "[2001:db8::1]:51820"
+            )
+        routes = {rule.rule for rule in broker_app.app.url_map.iter_rules()}
+        self.assertIn("/api/v3/config", routes)
+        self.assertIn(
+            "/api/v3/wg/key/exchange",
+            routes,
+        )
+
+    def test_config_route_rejects_prefix_without_two_64s(self):
+        from wgkex.broker import app as broker_app
+
+        ipam = mock.MagicMock()
+        ipam.get_or_allocate_prefix.return_value = (
+            None,
+            ipaddress.IPv6Network("2001:db8:42::/64"),
+            [],
+        )
+        query = {
+            "pubkey": "TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=",
+            "nonce": "nonce",
+        }
+        with mock.patch.object(broker_app, "ipam", ipam):
+            response = broker_app.app.test_client().get("/config", query_string=query)
+
+        self.assertEqual(response.status_code, 500)
+
+    def test_parker_mqtt_connect_keeps_legacy_discovery(self):
+        from wgkex.broker import app as broker_app
+        from wgkex.common.mqtt import MQTTTopics
+
+        mqtt = mock.MagicMock()
+        client = mock.MagicMock(host="mqtt", port=1883)
+        with mock.patch.object(broker_app, "mqtt", mqtt):
+            broker_app.handle_mqtt_connect(
+                client,
+                b"",
+                {},
+                paho.mqtt.enums.ConnackCode.CONNACK_ACCEPTED,
+            )
+
+        expected_subscriptions = {
+            MQTTTopics.TOPIC_CONNECTED_PEERS.format(worker="+", domain="+"),
+            MQTTTopics.TOPIC_WORKER_STATUS.format(worker="+"),
+            MQTTTopics.TOPIC_WORKER_WG_DATA.format(worker="+", domain="+"),
+            MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(broker="+"),
+            MQTTTopics.TOPIC_PARKER_CONNECTED_PEERS.format(worker="+"),
+            MQTTTopics.TOPIC_PARKER_WORKER_STATUS.format(worker="+"),
+            MQTTTopics.TOPIC_PARKER_WORKER_WG_DATA.format(worker="+"),
+            MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(broker="+"),
+        }
+        self.assertEqual(
+            {call.args[0] for call in mqtt.subscribe.call_args_list},
+            expected_subscriptions,
+        )
+        legacy_topic = MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(
+            broker=broker_app._HOSTNAME
+        )
+        parker_topic = MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(
+            broker=broker_app._HOSTNAME
+        )
+        mqtt.publish.assert_has_calls(
+            [
+                mock.call(legacy_topic, 1, qos=1, retain=True),
+                mock.call(parker_topic, b"", qos=1, retain=True),
+                mock.call(parker_topic, 1, qos=1, retain=False),
+            ]
+        )
+        self.assertEqual(broker_app.app.config["MQTT_LAST_WILL_TOPIC"], legacy_topic)
 
     def test_parker_mqtt_handlers(self):
         # Import app after config is set
@@ -155,6 +270,18 @@ class TestParker(unittest.TestCase):
 
         msg.payload = b"0"
         broker_app.handle_mqtt_message_parker_broker_status(None, None, msg)
+        self.assertNotIn("broker1", broker_app.parker_active_brokers)
+
+        broker_app.active_brokers.clear()
+        broker_app.parker_active_brokers.clear()
+        msg.topic = "wireguard-broker/broker1/status".encode("utf-8")
+        msg.payload = b"1"
+        broker_app.handle_mqtt_message_broker_status(None, None, msg)
+        self.assertIn("broker1", broker_app.active_brokers)
+        self.assertIn("broker1", broker_app.parker_active_brokers)
+        msg.payload = b"0"
+        broker_app.handle_mqtt_message_broker_status(None, None, msg)
+        self.assertNotIn("broker1", broker_app.active_brokers)
         self.assertNotIn("broker1", broker_app.parker_active_brokers)
 
     def test_get_active_brokers_count(self):

--- a/wgkex/broker/signer.py
+++ b/wgkex/broker/signer.py
@@ -90,7 +90,9 @@ def get_private_key() -> Tuple[KeyType, ecdsa.SigningKey, Optional[bytes]]:
     return (keytype, privkey, fingerprint_bytes)
 
 
-get_private_key()  # Ensure the private key is loaded at startup, and throws an error if it is invalid
+if config.get_config().parker.enabled:
+    # Validate the signing key at startup only when response signing is enabled.
+    get_private_key()
 
 
 def sign_response(data: bytes) -> bytes:

--- a/wgkex/broker/signer_test.py
+++ b/wgkex/broker/signer_test.py
@@ -1,0 +1,87 @@
+import base64
+import importlib
+import sys
+import unittest
+
+from wgkex.config import config
+
+
+def _parker_config(signing_key: str) -> config.Config:
+    return config.Config.from_dict(
+        {
+            "parker": {
+                "enabled": True,
+                "464xlat": True,
+                "ipam": "json",
+                "prefixes": {
+                    "ipv4": {"clat_subnet": "10.80.96.0/22"},
+                    "ipv6": {"length": 63},
+                },
+            },
+            "broker_signing_key": signing_key,
+            "domains": [],
+            "domain_prefixes": [],
+            "mqtt": {"broker_url": "", "username": "", "password": ""},
+        }
+    )
+
+
+class TestSigner(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        config._parsed_config = _parker_config(bytes(range(32)).hex())
+        cls.signer = importlib.import_module("wgkex.broker.signer")
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        config._parsed_config = None
+        sys.modules.pop("wgkex.broker.signer", None)
+
+    def tearDown(self) -> None:
+        self.signer.get_private_key.cache_clear()
+
+    def test_raw_key_signs_verifiable_response(self):
+        key_type, private_key, fingerprint = self.signer.get_private_key()
+        self.assertEqual(key_type, self.signer.KeyType.RAW)
+        self.assertIsNone(fingerprint)
+
+        data = b'{"result":"ok"}\n'
+        signature = base64.b64decode(self.signer.sign_response(data))
+        self.assertEqual(len(signature), 64)
+        self.assertTrue(private_key.verifying_key.verify(signature, data))
+
+    def test_signify_key_preserves_fingerprint_in_signature(self):
+        serialized_key = bytearray(104)
+        fingerprint = b"12345678"
+        serialized_key[32:40] = fingerprint
+        serialized_key[40:72] = bytes(range(32))
+        config._parsed_config = _parker_config(
+            base64.b64encode(serialized_key).decode()
+        )
+        self.signer.get_private_key.cache_clear()
+
+        key_type, private_key, loaded_fingerprint = self.signer.get_private_key()
+        self.assertEqual(key_type, self.signer.KeyType.SIGNIFY)
+        self.assertEqual(loaded_fingerprint, fingerprint)
+
+        data = b"response\n"
+        signature = base64.b64decode(self.signer.sign_response(data))
+        self.assertEqual(signature[:10], b"Ed" + fingerprint)
+        self.assertTrue(private_key.verifying_key.verify(signature[10:], data))
+
+    def test_signing_is_unavailable_when_parker_is_disabled(self):
+        config._parsed_config = config.Config.from_dict(
+            {
+                "domains": [],
+                "domain_prefixes": [],
+                "mqtt": {"broker_url": "", "username": "", "password": ""},
+            }
+        )
+        self.signer.get_private_key.cache_clear()
+
+        with self.assertRaisesRegex(ValueError, "non-parker mode"):
+            self.signer.get_private_key()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wgkex/broker/startup_test.py
+++ b/wgkex/broker/startup_test.py
@@ -1,0 +1,51 @@
+import importlib
+import sys
+import unittest
+
+import flask_mqtt
+import mock
+
+from wgkex.config import config
+
+
+class MqttStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def init_app(self, app, **kwargs):
+        return None
+
+    def on_topic(self, topic=None):
+        return lambda func: func
+
+    def on_connect(self):
+        return lambda func: func
+
+    def on_message(self):
+        return lambda func: func
+
+
+class TestBrokerStartup(unittest.TestCase):
+    def tearDown(self) -> None:
+        config._parsed_config = None
+        sys.modules.pop("wgkex.broker.app", None)
+        sys.modules.pop("wgkex.broker.signer", None)
+
+    def test_broker_imports_with_default_parker_disabled_config(self):
+        config._parsed_config = config.Config.from_dict(
+            {
+                "domains": [],
+                "domain_prefixes": [],
+                "mqtt": {"broker_url": "", "username": "", "password": ""},
+            }
+        )
+
+        with mock.patch.object(flask_mqtt, "Mqtt", MqttStub):
+            broker_app = importlib.import_module("wgkex.broker.app")
+
+        self.assertFalse(config.get_config().parker.enabled)
+        self.assertIsNone(broker_app.ipam)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wgkex/broker/startup_test.py
+++ b/wgkex/broker/startup_test.py
@@ -46,6 +46,28 @@ class TestBrokerStartup(unittest.TestCase):
         self.assertFalse(config.get_config().parker.enabled)
         self.assertIsNone(broker_app.ipam)
 
+    def test_parker_startup_eagerly_rejects_invalid_signing_key(self):
+        config._parsed_config = config.Config.from_dict(
+            {
+                "parker": {
+                    "enabled": True,
+                    "464xlat": True,
+                    "ipam": "json",
+                    "prefixes": {
+                        "ipv4": {"clat_subnet": "10.80.96.0/22"},
+                        "ipv6": {"length": 63},
+                    },
+                },
+                "broker_signing_key": "YQ==",
+                "domains": [],
+                "domain_prefixes": [],
+                "mqtt": {"broker_url": "", "username": "", "password": ""},
+            }
+        )
+
+        with self.assertRaisesRegex(ValueError, "Invalid private key length"):
+            importlib.import_module("wgkex.broker.signer")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wgkex/common/BUILD
+++ b/wgkex/common/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pip//:requirements.bzl", "requirement")
 
 

--- a/wgkex/config/BUILD
+++ b/wgkex/config/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pip//:requirements.bzl", "requirement")
 
 

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -286,6 +286,11 @@ class Parker:
             raise ValueError(
                 "Parker prefixes config must contain 'length' key for 'ipv6' when not using 464xlat"
             )
+        ipv6_prefix_length = int(pfx["ipv6"]["length"])
+        if not 0 <= ipv6_prefix_length <= 63:
+            raise ValueError(
+                "Parker IPv6 allocation prefix length must be between 0 and 63"
+            )
         if ipam == cls.IPAM.NETBOX and (
             "netbox_filter" not in pfx["ipv6"]
             or not isinstance(pfx["ipv6"]["netbox_filter"], dict)
@@ -318,7 +323,7 @@ class Parker:
                     netbox_additional_data=pfx["ipv6"].get(
                         "netbox_additional_data", None
                     ),
-                    length=pfx["ipv6"]["length"],
+                    length=ipv6_prefix_length,
                 ),
             ),
             ipam=ipam,

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -18,6 +18,26 @@ _INVALID_LINT = (
 _INVALID_CFG = "asdasdasdasd"
 
 
+def _config_dict() -> dict:
+    return {
+        "domains": ["_test_domain"],
+        "domain_prefixes": ["_test_"],
+        "mqtt": {"broker_url": "", "username": "", "password": ""},
+    }
+
+
+def _parker_dict() -> dict:
+    return {
+        "enabled": True,
+        "464xlat": True,
+        "ipam": "json",
+        "prefixes": {
+            "ipv4": {"clat_subnet": "10.80.96.0/22"},
+            "ipv6": {"length": 63},
+        },
+    }
+
+
 class TestConfig(unittest.TestCase):
     def tearDown(self) -> None:
         config._parsed_config = None
@@ -109,6 +129,99 @@ class TestConfig(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         config.get_config()
                 config._parsed_config = None
+
+    def test_worker_tolerance_bounds_are_validated(self):
+        for tolerance in (-1, 101):
+            with self.subTest(tolerance=tolerance):
+                with self.assertRaisesRegex(ValueError, "between 0 and 100"):
+                    config.Workers.from_dict({}, tolerance)
+
+    def test_parker_prefix_structure_validation(self):
+        invalid_configs = [
+            {"enabled": True, "464xlat": True, "ipam": "json"},
+            {
+                "enabled": True,
+                "464xlat": True,
+                "ipam": "json",
+                "prefixes": [],
+            },
+            {
+                "enabled": True,
+                "464xlat": True,
+                "ipam": "json",
+                "prefixes": {"ipv4": {}},
+            },
+            {
+                "enabled": True,
+                "464xlat": True,
+                "ipam": "json",
+                "prefixes": {"ipv4": {}, "ipv6": {"length": 63}},
+            },
+            {
+                "enabled": True,
+                "464xlat": True,
+                "ipam": "json",
+                "prefixes": {
+                    "ipv4": {"clat_subnet": "10.80.96.0/22"},
+                    "ipv6": {},
+                },
+            },
+        ]
+        for parker in invalid_configs:
+            with self.subTest(parker=parker), self.assertRaises(ValueError):
+                config.Parker.from_dict(parker)
+
+    def test_netbox_and_non_xlat_validation(self):
+        parker = _parker_dict()
+        parker["ipam"] = "netbox"
+        with self.assertRaisesRegex(ValueError, "ipv6"):
+            config.Parker.from_dict(parker)
+
+        parker["prefixes"]["ipv6"]["netbox_filter"] = {"role": "wgkex"}
+        parsed = config.Parker.from_dict(parker)
+        self.assertEqual(parsed.ipam, config.Parker.IPAM.NETBOX)
+
+        parker["464xlat"] = False
+        parker["prefixes"]["ipv4"] = {}
+        with self.assertRaisesRegex(ValueError, "length"):
+            config.Parker.from_dict(parker)
+
+        parker["prefixes"]["ipv4"]["length"] = 24
+        with self.assertRaisesRegex(ValueError, "netbox_filter"):
+            config.Parker.from_dict(parker)
+
+        parker["prefixes"]["ipv4"]["netbox_filter"] = {"role": "wgkex-v4"}
+        with self.assertRaises(NotImplementedError):
+            config.Parker.from_dict(parker)
+
+    def test_parker_config_requires_signing_and_netbox_credentials(self):
+        cfg = _config_dict()
+        cfg["parker"] = _parker_dict()
+        with self.assertRaisesRegex(ValueError, "broker_signing_key"):
+            config.Config.from_dict(cfg)
+
+        cfg["broker_signing_key"] = "key"
+        cfg["parker"]["ipam"] = "netbox"
+        cfg["parker"]["prefixes"]["ipv6"]["netbox_filter"] = {"role": "wgkex"}
+        with self.assertRaisesRegex(ValueError, "no netbox config"):
+            config.Config.from_dict(cfg)
+
+        cfg["netbox"] = {"url": "https://netbox", "api_key": "token"}
+        parsed = config.Config.from_dict(cfg)
+        self.assertEqual(parsed.netbox.url, "https://netbox")
+        self.assertEqual(parsed.netbox.api_key, "token")
+
+    def test_yaml_parser_error_exits(self):
+        with (
+            mock.patch.object(
+                config.yaml, "safe_load", side_effect=yaml.YAMLError("invalid")
+            ),
+            mock.patch.object(config.sys, "exit", side_effect=SystemExit(1)) as exit,
+            mock.patch("builtins.open", mock.mock_open(read_data="invalid")),
+            self.assertRaises(SystemExit),
+        ):
+            config.get_config()
+        exit.assert_called_once_with(1)
 
 
 if __name__ == "__main__":

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -89,6 +89,27 @@ class TestConfig(unittest.TestCase):
             with self.assertRaises(ValueError):
                 config.get_config()
 
+    def test_parker_ipv6_prefix_length_must_contain_two_64s(self):
+        for prefix_length in (-1, 64, 128, "invalid"):
+            with self.subTest(prefix_length=prefix_length):
+                mock_open = mock.mock_open(
+                    read_data=_VALID_CFG
+                    + "\nparker:\n"
+                    + "  enabled: true\n"
+                    + "  ipam: json\n"
+                    + "  464xlat: true\n"
+                    + "  prefixes:\n"
+                    + "    ipv4:\n"
+                    + "      clat_subnet: 10.80.96.0/22\n"
+                    + "    ipv6:\n"
+                    + f"      length: {prefix_length}\n"
+                    + "broker_signing_key: asdfasdfasdf"
+                )
+                with mock.patch("builtins.open", mock_open):
+                    with self.assertRaises(ValueError):
+                        config.get_config()
+                config._parsed_config = None
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wgkex/worker/BUILD
+++ b/wgkex/worker/BUILD
@@ -84,5 +84,16 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
        "//wgkex/common:logger",
+       ":netlink",
     ],
+)
+
+py_test(
+    name = "msg_queue_test",
+    srcs = ["msg_queue_test.py"],
+    deps = [
+       ":msg_queue",
+       requirement("mock"),
+    ],
+    size="small",
 )

--- a/wgkex/worker/BUILD
+++ b/wgkex/worker/BUILD
@@ -1,4 +1,4 @@
-load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@pip//:requirements.bzl", "requirement")
 
 

--- a/wgkex/worker/app_test.py
+++ b/wgkex/worker/app_test.py
@@ -119,6 +119,68 @@ class AppTest(unittest.TestCase):
         self.assertTrue(thread.is_alive())
         # If Python would allow it without writing custom signalling, this would be the place to stop the thread again
 
+    @mock.patch.object(app.threading, "Thread")
+    def test_cleanup_schedules_parker_and_legacy_domains(self, thread):
+        app.clean_up_worker(True)
+        thread.assert_called_once_with(
+            target=app.flush_workers, args=(True, "parker"), daemon=True
+        )
+        thread.return_value.start.assert_called_once()
+
+        thread.reset_mock()
+        with mock.patch.object(
+            app.config,
+            "get_config",
+            return_value=_get_config_mock(
+                domains=["_TEST_PREFIX_domain.one", "unmatched"]
+            ),
+        ):
+            app.clean_up_worker(False)
+        thread.assert_called_once_with(
+            target=app.flush_workers, args=(False, "domain.one"), daemon=True
+        )
+        thread.return_value.start.assert_called_once()
+
+    @mock.patch.object(app.config, "get_config")
+    def test_main_parker_registers_shutdown_and_starts_components(self, config_mock):
+        config_mock.return_value = _get_config_mock(parker=mock.MagicMock(enabled=True))
+        callbacks = []
+        with (
+            mock.patch.object(
+                app.signal,
+                "signal",
+                side_effect=lambda _, callback: callbacks.append(callback),
+            ),
+            mock.patch.object(app, "clean_up_worker") as cleanup,
+            mock.patch.object(app, "watch_queue") as watch_queue,
+            mock.patch.object(app.mqtt, "connect") as connect,
+        ):
+            app.main()
+
+        cleanup.assert_called_once_with(True)
+        watch_queue.assert_called_once_with(True)
+        connect.assert_called_once()
+        self.assertEqual(len(callbacks), 2)
+
+        with (
+            mock.patch.object(app.time, "sleep") as sleep,
+            mock.patch.object(app.sys, "exit") as exit_process,
+        ):
+            callbacks[0](app.signal.SIGINT, None)
+        sleep.assert_called_once_with(2)
+        exit_process.assert_called_once()
+
+    @mock.patch.object(app.config, "get_config")
+    def test_main_rejects_duplicate_stripped_domains(self, config_mock):
+        config_mock.return_value = _get_config_mock(
+            domains=["_TEST_PREFIX_same", "_TEST_PREFIX2_same"]
+        )
+        with (
+            mock.patch.object(app.signal, "signal"),
+            self.assertRaises(app.DomainsAreNotUnique),
+        ):
+            app.main()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wgkex/worker/mqtt_test.py
+++ b/wgkex/worker/mqtt_test.py
@@ -285,6 +285,119 @@ class MQTTTest(unittest.TestCase):
         item = mqtt.q.get_nowait()
         self.assertEqual(item, ("domain1", "PUB_KEY"))
 
+    @mock.patch.object(mqtt.threading, "Thread")
+    @mock.patch.object(mqtt.mqtt, "Client")
+    @mock.patch.object(mqtt, "get_config")
+    def test_connect_parker_registers_callbacks_and_background_tasks(
+        self, config_mock, mqtt_client, thread
+    ):
+        cfg = _get_config_mock(
+            mqtt=mock.MagicMock(
+                broker_url="mqtt",
+                broker_port=1883,
+                username="user",
+                password="password",
+                keepalive=5,
+            ),
+            parker=mock.MagicMock(enabled=True),
+        )
+        config_mock.return_value = cfg
+        client = mqtt_client.return_value
+
+        mqtt.connect(threading.Event())
+
+        client.will_set.assert_called_once_with(
+            MQTTTopics.TOPIC_PARKER_WORKER_STATUS.format(worker=socket.gethostname()),
+            0,
+            qos=1,
+            retain=True,
+        )
+        client.message_callback_add.assert_called_once_with(
+            "parker/wireguard/#", mqtt.on_message_parker
+        )
+        self.assertEqual(thread.call_count, 2)
+        client.loop_forever.assert_called_once()
+
+    @mock.patch.object(mqtt, "get_config")
+    def test_on_connect_failure_and_legacy_missing_interface(self, config_mock):
+        cfg = _get_config_mock()
+        cfg.external_name = "worker.example"
+        config_mock.return_value = cfg
+        client = mock.MagicMock(host="mqtt", port=1883)
+
+        mqtt.on_connect(client, None, None, 1)
+        client.subscribe.assert_not_called()
+
+        with mock.patch.object(mqtt, "wg_interface_name", return_value=None):
+            mqtt.on_connect(
+                client,
+                None,
+                None,
+                paho.mqtt.enums.ConnackCode.CONNACK_ACCEPTED,
+            )
+        client.publish.assert_called_with(
+            MQTTTopics.TOPIC_WORKER_STATUS.format(worker=socket.gethostname()),
+            1,
+            qos=1,
+            retain=True,
+        )
+
+    @mock.patch.object(mqtt, "get_config")
+    def test_message_parsers_reject_unknown_domain_and_queue_parker(self, config_mock):
+        config_mock.return_value = _get_config_mock()
+        message = paho.mqtt.client.MQTTMessage()
+        message.topic = "wireguard/no-match/all".encode()
+        message.payload = b"key"
+        with self.assertRaisesRegex(ValueError, "Could not find a match"):
+            mqtt.on_message_wireguard(None, None, message)
+
+        message.topic = "parker/wireguard/all".encode()
+        message.payload = b'{"PublicKey":"key"}'
+        mqtt.on_message_parker(None, None, message)
+        self.assertEqual(mqtt.q.get_nowait(), '{"PublicKey":"key"}')
+        mqtt.on_message(None, None, message)
+
+    def test_metrics_loop_validation_exception_and_offline_publish(self):
+        with self.assertRaisesRegex(ValueError, "Domain must be passed"):
+            mqtt.publish_metrics_loop(threading.Event(), mock.MagicMock(), None, False)
+
+        exit_event = mock.MagicMock()
+        exit_event.is_set.side_effect = [False, True]
+        client = mock.MagicMock()
+        with mock.patch.object(
+            mqtt, "publish_metrics_parker", side_effect=RuntimeError("failed")
+        ):
+            mqtt.publish_metrics_loop(exit_event, client, None, True)
+        client.publish.assert_called_once_with(
+            MQTTTopics.TOPIC_PARKER_CONNECTED_PEERS.format(worker=socket.gethostname()),
+            -1,
+            qos=1,
+            retain=True,
+        )
+
+    @mock.patch.object(mqtt, "wg_interface_name", return_value=None)
+    def test_publish_metrics_skips_missing_interface(self, _):
+        client = mock.MagicMock()
+        mqtt.publish_metrics(client, "topic", "_test_domain")
+        client.publish.assert_not_called()
+
+    @mock.patch.object(
+        mqtt,
+        "get_connected_peers_count",
+        side_effect=pyroute2.netlink.exceptions.NetlinkDumpInterrupted(),
+    )
+    def test_publish_parker_metrics_handles_interrupted_dump(self, _):
+        client = mock.MagicMock()
+        mqtt.publish_metrics_parker(client, "topic")
+        client.publish.assert_not_called()
+
+    @mock.patch.object(mqtt, "get_config")
+    def test_wireguard_interface_name_validation(self, config_mock):
+        config_mock.return_value = _get_config_mock()
+        self.assertEqual(mqtt.wg_interface_name("_TEST_PREFIX2_domain"), "wg-domain")
+        with self.assertRaisesRegex(ValueError, "Could not find a match"):
+            mqtt.wg_interface_name("unknown")
+
 
 """ @mock.patch.object(msg_queue, "link_handler")
     @mock.patch.object(mqtt, "get_config")

--- a/wgkex/worker/msg_queue.py
+++ b/wgkex/worker/msg_queue.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 import json
 import threading
-from queue import Queue
-from time import sleep
+from queue import Empty, Queue
 
 from wgkex.common import logger
 from wgkex.worker.netlink import (
@@ -36,38 +35,58 @@ def watch_queue(parker: bool = False) -> None:
     threading.Thread(target=pick_from_queue, args=[parker], daemon=True).start()
 
 
-def pick_from_queue(parker: bool = False) -> None:
+def _process_queue_item(item, parker: bool) -> None:
+    if parker:
+        message = json.loads(item)
+        client = ParkerWireGuardClient(
+            # TODO use shared data class
+            public_key=message.get("PublicKey"),
+            range6=message.get("Range6"),
+            keepalive=message.get("Keepalive"),
+            remove=False,
+        )
+        logger.info(
+            "Processing queue for key %s with range %s",
+            client.public_key,
+            client.range6,
+        )
+    else:
+        domain, message = item
+        logger.debug("Processing queue item %s for domain %s", message, domain)
+        client = WireGuardClient(
+            public_key=message,
+            domain=domain,
+            remove=False,
+        )
+        logger.info(
+            "Processing queue for key %s on domain %s with lladdr %s",
+            client.public_key,
+            domain,
+            client.lladdr,
+        )
+    logger.debug(link_handler(client))
+
+
+def pick_from_queue(
+    parker: bool = False,
+    work_queue: Queue = q,
+    stop_event: threading.Event | None = None,
+) -> None:
     """Picks a message from the queue and processes it."""
     logger.debug("Starting queue processor")
-    while True:
-        if not q.empty():
-            logger.debug("Queue is not empty current size is %i", q.qsize())
+    while stop_event is None or not stop_event.is_set():
+        try:
+            item = work_queue.get(timeout=0.1)
+        except Empty:
+            continue
 
-            if parker:
-                message = json.loads(q.get())
-                client = ParkerWireGuardClient(
-                    # TODO use shared data class
-                    public_key=message.get("PublicKey"),
-                    range6=message.get("Range6"),
-                    keepalive=message.get("Keepalive"),
-                    remove=False,
-                )
-                logger.info(
-                    f"Processing queue for key {client.public_key} with range {client.range6}"
-                )
-            else:
-                domain, message = q.get()
-                logger.debug("Processing queue item %s for domain %s", message, domain)
-                client = WireGuardClient(
-                    public_key=message,
-                    domain=domain,
-                    remove=False,
-                )
-                logger.info(
-                    f"Processing queue for key {client.public_key} on domain {domain} with lladdr {client.lladdr}"
-                )
-            logger.debug(link_handler(client))
-            q.task_done()
-        else:
-            logger.debug("Queue is empty")
-            sleep(1)
+        try:
+            _process_queue_item(item, parker)
+        except Exception as error:
+            logger.error(
+                "Failed to process queue item %r; continuing with the next item",
+                item,
+                exc_info=error,
+            )
+        finally:
+            work_queue.task_done()

--- a/wgkex/worker/msg_queue_test.py
+++ b/wgkex/worker/msg_queue_test.py
@@ -1,0 +1,76 @@
+import json
+import threading
+import time
+import unittest
+from queue import Queue
+
+import mock
+
+from wgkex.worker import msg_queue
+
+
+class TestMessageQueue(unittest.TestCase):
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_bad_item_does_not_stop_processing_or_break_accounting(self, link_handler):
+        work_queue = Queue()
+        stop_event = threading.Event()
+        processor = threading.Thread(
+            target=msg_queue.pick_from_queue,
+            args=(True, work_queue, stop_event),
+            daemon=True,
+        )
+        processor.start()
+
+        work_queue.put("{malformed")
+        work_queue.put("[]")
+        work_queue.put(
+            json.dumps(
+                {
+                    "PublicKey": "valid-key",
+                    "Range6": "2001:db8::/63",
+                    "Keepalive": 25,
+                }
+            )
+        )
+
+        deadline = time.monotonic() + 5
+        while work_queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        stop_event.set()
+        processor.join(timeout=1)
+
+        self.assertEqual(work_queue.unfinished_tasks, 0)
+        self.assertEqual(link_handler.call_count, 1)
+        self.assertEqual(link_handler.call_args.args[0].public_key, "valid-key")
+
+    @mock.patch.object(
+        msg_queue, "link_handler", side_effect=[RuntimeError("netlink failed"), {}]
+    )
+    def test_netlink_failure_does_not_stop_following_item(self, link_handler):
+        work_queue = Queue()
+        stop_event = threading.Event()
+        processor = threading.Thread(
+            target=msg_queue.pick_from_queue,
+            args=(False, work_queue, stop_event),
+            daemon=True,
+        )
+        processor.start()
+
+        work_queue.put(("domain", "first-key"))
+        work_queue.put(("domain", "second-key"))
+
+        deadline = time.monotonic() + 5
+        while work_queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        stop_event.set()
+        processor.join(timeout=1)
+
+        self.assertEqual(work_queue.unfinished_tasks, 0)
+        self.assertEqual(link_handler.call_count, 2)
+        self.assertEqual(link_handler.call_args.args[0].public_key, "second-key")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses the confirmed audit findings in #202:

- add Parker-compatible `GET /config` while preserving the v3 aliases
- keep Parker configuration and signing-key validation out of disabled-mode startup
- retain legacy v1/v2 MQTT discovery alongside Parker topics, with canonical crash-safe broker liveness
- make JSON IPAM allocation process-safe with file locking and atomic replacement
- reconcile concurrent NetBox allocations deterministically and release duplicates
- isolate worker queue failures per item while preserving task accounting
- require Parker IPv6 allocations to contain two `/64` children and fail defensively at runtime
- format IPv6 concentrator endpoints with brackets
- create kernel WireGuard interfaces in the devcontainer and fail clearly when the host cannot support them
- complete the Bazel 9 migration from #233: pin Bazel 9.0.0 in `.bazelversion` and the Docker builder, load Python rules explicitly in every BUILD package, make `rules_python` 1.7.0 the direct dependency, and regenerate the Bazel 9 lockfile
- scope CI instrumentation to `//wgkex` while still running all 14 test targets, so the generated dependency-lock consistency test remains tested without trying to collect source coverage from its external rules_python runner

## Coverage

Measured with the repository's Bazel/LCOV workflow, including line and branch coverage:

- `main` baseline: **93.478% combined** — 1006/1051 lines (**95.718%**) and 284/329 branches (**86.322%**)
- final Bazel 9 branch, local production-focused report: **94.121% combined** — 1397/1429 lines (**97.761%**) and 508/595 branches (**85.378%**)
- final CI-style Bazel 9 report: **96.194% combined**
- Coveralls `main`: **93.541%**
- Coveralls this branch: **96.194%** ([build](https://coveralls.io/builds/80550274)); both coverage contexts pass

The added tests exercise broker v1/v2/v3 and `/config` behavior, disabled startup, signer formats, MQTT callback failure and recovery paths, JSON allocation concurrency, NetBox allocation races and cleanup failures, worker startup/shutdown and queue resilience, and configuration edge cases.

## Tests

- Bazel 9.0.0 `test ...:all --test_output=errors --action_env=WGKEX_CONFIG_FILE=...` — 14/14 passed
- Bazel 9.0.0 CI coverage command with `--instrument_test_targets` and `--instrumentation_filter=//wgkex` — 14/14 passed
- Bazel 9.0.0 module resolution with `--lockfile_mode=error`
- `docker build --platform linux/amd64 -t wgkex:bazel9-audit .`
- `black --check wgkex`
- `ruff check wgkex`
- `bash -n .devcontainer/docker-entrypoint.sh`
- `docker compose -f docker-compose.yml -f .devcontainer/docker-compose.yml config --quiet`
- GitHub Actions: Bazel, Coveralls upload, Docker build, Black, and Ruff all pass