### PR TITLE
worker: reliably clean up offline WireGuard peers

### DIFF
--- a/PARKER.md
+++ b/PARKER.md
@@ -19,10 +19,40 @@ For Parker the following configuration items are relevant in addition to the def
 - `sticky_worker_tolerance`
 - `broker_signing_key`
 - `parker` section
+- `cleanup` section
 - `netbox` section
 
 
 ## Design considerations
+
+### Offline peer cleanup
+
+The Parker worker defaults to a 300-second stale-handshake timeout and a
+600-second initial-handshake grace. The stale timeout accommodates the default
+120-second config retry and 180-second WireGuard tunnel timeout. Zero or missing
+handshake timestamps mean that a peer has never handshaked; they do not cause
+immediate deletion. Accepted queue updates refresh an in-memory, bounded
+provisioning tracker, and cleanup serializes only with updates for the same
+public key or assigned prefix.
+
+WireGuard does not expose peer creation time. After a worker restart, every
+untracked never-handshaked peer therefore receives one grace period from worker
+startup. Truly abandoned peers are removed on a later sweep rather than retained
+forever. The tracker retains at most 65,536 peer timestamps; if that bound is
+reached before entries age out, new provisioning fails explicitly rather than
+dropping grace state and risking premature cleanup.
+
+For a stale Parker peer, cleanup removes the selected assigned-prefix route
+before removing the WireGuard peer. If another current peer owns the prefix, its
+route is preserved. A real route or peer failure is reported and retried on the
+next sweep; already-absent state is treated as idempotent.
+
+When an accepted queue update reassigns a peer, the worker locks both the old
+and new prefixes, installs the new peer state and route, then removes the old
+route. `Range6` must match the configured Parker IPv6 allocation prefix length.
+If old-route deletion fails after reassignment, the bounded worker-side tracker
+retries it on cleanup sweeps after checking that no current peer owns it. This
+prevents cleanup from preserving a route that the peer immediately abandons.
 
 ### Concentrator selection
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [Backend worker](#backend-worker)
   - [Installation](#installation)
   - [Configuration](#configuration)
+    - [Worker peer cleanup](#worker-peer-cleanup)
   - [Development](#development)
     - [Build using Bazel](#build-using-bazel)
     - [Updating PIP dependencies for Bazel](#updating-pip-dependencies-for-bazel)
@@ -151,6 +152,29 @@ For further information, please see this [presentation on the architecture](http
 
 The `wgkex` configuration file defaults to `/etc/wgkex.yaml` ([Sample configuration file](wgkex.yaml.example)), however
 can also be overwritten by setting the environment variable `WGKEX_CONFIG_FILE`.
+
+### Worker peer cleanup
+
+Workers periodically remove offline WireGuard peers. A peer with a non-zero
+last-handshake timestamp is stale when its age is greater than or equal to the
+mode-specific timeout. A peer that has never handshaked is retained for
+`cleanup.initial_handshake_grace` after its most recent accepted queue update.
+After a worker restart, the kernel does not expose peer creation time, so all
+untracked never-handshaked peers receive one grace period starting at worker
+startup; abandoned peers are removed by the first later sweep.
+
+Cleanup scans do not block MQTT ingestion. Queue updates and cleanup serialize
+mutations for the same public key or Parker prefix. Parker deletion removes the
+assigned prefix route before the WireGuard peer, unless another current peer
+owns that prefix. Legacy deletion removes the FDB entry, then route, then peer.
+Already-absent dependencies are idempotent; other partial failures are reported
+and retried while the peer remains discoverable. Parker prefix reassignment
+locks both old and new prefixes and removes the old route after installing the
+new peer state and route; failed old-route deletion is retained and retried on
+later cleanup sweeps after an ownership check.
+
+See `wgkex.yaml.example` for the cleanup interval, Parker and legacy stale
+timeouts, and initial-handshake grace defaults.
 
 ## Development
 

--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -42,6 +42,18 @@ workers:
 sticky_worker_tolerance: 15
 # [worker] The external hostname of this worker
 externalName: gw04.ext.ffmuc.net
+# [worker] Offline peer cleanup timing, in seconds. All values must be positive.
+cleanup:
+  # How often each WireGuard interface is scanned.
+  interval: 3600
+  # A Parker peer with an earlier last handshake is stale. The default allows
+  # multiple 120s config retries and the 180s WireGuard tunnel timeout.
+  parker_stale_timeout: 300
+  # Preserve the historical three-hour timeout for legacy peers.
+  legacy_stale_timeout: 10800
+  # Never-handshaked peers are retained this long after provisioning or worker
+  # startup, then treated as abandoned.
+  initial_handshake_grace: 600
 # [broker, worker]
 parker:
   # Enable Parker support. The broker will still handle non-Parker in the same instance, the worker however will disable non-Parker support in this case.

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import logging
+import math
 import os
 import sys
 from enum import Enum
@@ -16,6 +17,19 @@ class Error(Exception):
 
 class ConfigFileNotFoundError(Error):
     """File could not be found on disk."""
+
+
+def _positive_duration(value: Any, name: str) -> float:
+    """Parse a finite, positive duration in seconds."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive duration in seconds")
+    try:
+        duration = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be a positive duration in seconds") from error
+    if not math.isfinite(duration) or duration <= 0:
+        raise ValueError(f"{name} must be a positive duration in seconds")
+    return duration
 
 
 WG_CONFIG_OS_ENV = "WGKEX_CONFIG_FILE"
@@ -171,6 +185,42 @@ class MQTT:
             broker_port=int(mqtt_cfg.get("broker_port", cls.broker_port)),
             keepalive=int(mqtt_cfg.get("keepalive", cls.keepalive)),
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class Cleanup:
+    """Worker peer cleanup timing in seconds."""
+
+    interval: float = 3600
+    parker_stale_timeout: float = 300
+    legacy_stale_timeout: float = 10800
+    initial_handshake_grace: float = 600
+
+    @classmethod
+    def from_dict(cls, cleanup_cfg: Dict[str, Any]) -> "Cleanup":
+        if not isinstance(cleanup_cfg, dict):
+            raise ValueError("cleanup must be a mapping")
+        return cls(
+            interval=_positive_duration(
+                cleanup_cfg.get("interval", cls.interval), "cleanup.interval"
+            ),
+            parker_stale_timeout=_positive_duration(
+                cleanup_cfg.get("parker_stale_timeout", cls.parker_stale_timeout),
+                "cleanup.parker_stale_timeout",
+            ),
+            legacy_stale_timeout=_positive_duration(
+                cleanup_cfg.get("legacy_stale_timeout", cls.legacy_stale_timeout),
+                "cleanup.legacy_stale_timeout",
+            ),
+            initial_handshake_grace=_positive_duration(
+                cleanup_cfg.get("initial_handshake_grace", cls.initial_handshake_grace),
+                "cleanup.initial_handshake_grace",
+            ),
+        )
+
+    def stale_timeout(self, parker: bool) -> float:
+        """Return the stale timeout for the selected worker mode."""
+        return self.parker_stale_timeout if parker else self.legacy_stale_timeout
 
 
 @dataclasses.dataclass
@@ -389,6 +439,7 @@ class Config:
     domain_prefixes: List[str]
     workers: Workers
     parker: Parker
+    cleanup: Cleanup
     external_name: Optional[str]
     mqtt: MQTT
     broker_listen: BrokerListen
@@ -410,6 +461,7 @@ class Config:
             cfg.get("workers", {}), cfg.get("sticky_worker_tolerance", 10)
         )
         parker = Parker.from_dict(cfg.get("parker", {}))
+        cleanup = Cleanup.from_dict(cfg.get("cleanup", {}))
         broker_signing_key = cfg.get("broker_signing_key", None)
 
         netbox_cfg = None
@@ -428,6 +480,7 @@ class Config:
             workers=workers_cfg,
             external_name=cfg.get("externalName"),
             parker=parker,
+            cleanup=cleanup,
             netbox=netbox_cfg,
             broker_signing_key=broker_signing_key,
         )

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -182,6 +182,43 @@ class TestConfig(unittest.TestCase):
         workers = config.Workers.from_dict({"worker": {"weight": 0}}, 10)
         self.assertEqual(workers.get("worker").weight, 0)
 
+    def test_cleanup_defaults_and_mode_timeouts(self):
+        cleanup = config.Cleanup.from_dict({})
+        self.assertEqual(cleanup.interval, 3600)
+        self.assertEqual(cleanup.stale_timeout(True), 300)
+        self.assertEqual(cleanup.stale_timeout(False), 10800)
+        self.assertEqual(cleanup.initial_handshake_grace, 600)
+
+        cfg = _config_dict()
+        cfg["cleanup"] = {
+            "interval": 30,
+            "parker_stale_timeout": 600,
+            "legacy_stale_timeout": 7200,
+            "initial_handshake_grace": 900,
+        }
+        parsed = config.Config.from_dict(cfg)
+        self.assertEqual(parsed.cleanup.interval, 30)
+        self.assertEqual(parsed.cleanup.stale_timeout(True), 600)
+        self.assertEqual(parsed.cleanup.stale_timeout(False), 7200)
+        self.assertEqual(parsed.cleanup.initial_handshake_grace, 900)
+
+    def test_cleanup_durations_are_positive_and_finite(self):
+        fields = (
+            "interval",
+            "parker_stale_timeout",
+            "legacy_stale_timeout",
+            "initial_handshake_grace",
+        )
+        for field in fields:
+            for value in (0, -1, True, "invalid", float("inf"), None):
+                with (
+                    self.subTest(field=field, value=value),
+                    self.assertRaisesRegex(ValueError, field),
+                ):
+                    config.Cleanup.from_dict({field: value})
+        with self.assertRaisesRegex(ValueError, "mapping"):
+            config.Cleanup.from_dict([])  # type: ignore
+
     def test_parker_prefix_structure_validation(self):
         invalid_configs = [
             {"enabled": True, "464xlat": True, "ipam": "json"},

--- a/wgkex/worker/BUILD
+++ b/wgkex/worker/BUILD
@@ -3,6 +3,20 @@ load("@pip//:requirements.bzl", "requirement")
 
 
 py_library(
+    name = "peer_state",
+    srcs = ["peer_state.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "peer_state_test",
+    srcs = ["peer_state_test.py"],
+    deps = [":peer_state"],
+    size = "small",
+)
+
+
+py_library(
     name = "netlink",
     srcs = ["netlink.py"],
     visibility = ["//visibility:public"],
@@ -13,6 +27,7 @@ py_library(
        "//wgkex/common:utils",
        "//wgkex/common:logger",
        "//wgkex/config:config",
+       ":peer_state",
     ],
 )
 
@@ -42,6 +57,7 @@ py_library(
        "//wgkex/config:config",
        ":msg_queue",
        ":netlink",
+       ":peer_state",
     ],
 )
 
@@ -62,6 +78,7 @@ py_binary(
     deps = [
        ":mqtt",
        ":msg_queue",
+       ":peer_state",
        "//wgkex/config:config",
        "//wgkex/common:logger",
     ],
@@ -85,6 +102,7 @@ py_library(
     deps = [
        "//wgkex/common:logger",
        ":netlink",
+       ":peer_state",
     ],
 )
 
@@ -93,6 +111,8 @@ py_test(
     srcs = ["msg_queue_test.py"],
     deps = [
        ":msg_queue",
+       ":netlink",
+       ":peer_state",
        requirement("mock"),
     ],
     size="small",

--- a/wgkex/worker/app.py
+++ b/wgkex/worker/app.py
@@ -3,7 +3,6 @@
 import signal
 import sys
 import threading
-import time
 from typing import Text
 
 from wgkex.common import logger
@@ -12,8 +11,7 @@ from wgkex.config import config
 from wgkex.worker import mqtt
 from wgkex.worker.msg_queue import watch_queue
 from wgkex.worker.netlink import wg_flush_stale_peers
-
-_CLEANUP_TIME = 3600
+from wgkex.worker.peer_state import PeerMutationCoordinator, peer_mutations
 
 
 class Error(Exception):
@@ -36,20 +34,51 @@ class InvalidDomain(Error):
     """If the domains is invalid and is not listed in the configuration file."""
 
 
-def flush_workers(parker: bool, domain: Text) -> None:
-    """Calls peer flush every _CLEANUP_TIME interval."""
-    while True:
+def flush_workers(
+    exit_event: threading.Event,
+    parker: bool,
+    domain: Text,
+    cleanup: config.Cleanup,
+    parker_prefix_length: int = 63,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+) -> None:
+    """Flush stale peers on an interruptible interval until shutdown."""
+    while not exit_event.wait(cleanup.interval):
         try:
-            time.sleep(_CLEANUP_TIME)
-            logger.info(f"Running cleanup task for {domain}")
-            logger.info("Cleaned up domains: %s", wg_flush_stale_peers(parker, domain))
-        except Exception as e:
-            # Don't crash the thread when an exception is encountered
-            logger.error(f"Exception during cleanup task for {domain}:")
-            logger.error(e)
+            logger.info("Running cleanup task domain=%s parker=%s", domain, parker)
+            results = wg_flush_stale_peers(
+                parker,
+                domain,
+                stale_timeout=cleanup.stale_timeout(parker),
+                initial_handshake_grace=cleanup.initial_handshake_grace,
+                parker_prefix_length=parker_prefix_length,
+                coordinator=coordinator,
+            )
+            logger.info(
+                "Cleanup task completed domain=%s parker=%s selected=%s "
+                "deleted=%s deferred=%s failed=%s",
+                domain,
+                parker,
+                len(results),
+                sum(result.status == "deleted" for result in results),
+                sum(result.status == "deferred" for result in results),
+                sum(result.status == "failed" for result in results),
+            )
+        except Exception as error:
+            logger.error(
+                "Cleanup sweep failed domain=%s parker=%s",
+                domain,
+                parker,
+                exc_info=error,
+            )
 
 
-def clean_up_worker(parker: bool) -> None:
+def clean_up_worker(
+    parker: bool,
+    exit_event: threading.Event,
+    worker_config: config.Config,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+) -> list[threading.Thread]:
     """Wraps flush_workers in a thread for all given domains.
 
     Arguments:
@@ -57,15 +86,25 @@ def clean_up_worker(parker: bool) -> None:
     """
     if parker:
         thread = threading.Thread(
-            target=flush_workers, args=(parker, "parker"), daemon=True
+            target=flush_workers,
+            args=(
+                exit_event,
+                parker,
+                "parker",
+                worker_config.cleanup,
+                worker_config.parker.prefixes.ipv6.length,
+                coordinator,
+            ),
+            name="peer-cleanup-parker",
         )
         thread.start()
-        return
+        return [thread]
 
-    domains = config.get_config().domains
-    prefixes = config.get_config().domain_prefixes
+    domains = worker_config.domains
+    prefixes = worker_config.domain_prefixes
     logger.debug("Cleaning up the following domains: %s", domains)
     cleanup_counter = 0
+    threads = []
     # ToDo: do we need a check if every domain got gleaned?
     for prefix in prefixes:
         for domain in domains:
@@ -82,15 +121,26 @@ def clean_up_worker(parker: bool) -> None:
                     )
                     continue
                 thread = threading.Thread(
-                    target=flush_workers, args=(parker, cleaned_domain), daemon=True
+                    target=flush_workers,
+                    args=(
+                        exit_event,
+                        parker,
+                        cleaned_domain,
+                        worker_config.cleanup,
+                        63,
+                        coordinator,
+                    ),
+                    name=f"peer-cleanup-{cleaned_domain}",
                 )
                 thread.start()
+                threads.append(thread)
     if cleanup_counter < len(domains):
         logger.error(
             "Not every domain got cleaned. Check domains %s for missing prefixes %s",
             repr(domains),
             repr(prefixes),
         )
+    return threads
 
 
 def check_all_domains_unique(domains, prefixes):
@@ -131,18 +181,18 @@ def main():
     def on_exit(sig_number, stack_frame) -> None:
         logger.info("Shutting down...")
         exit_event.set()
-        time.sleep(2)
         sys.exit()
 
     signal.signal(signal.SIGINT, on_exit)
     signal.signal(signal.SIGTERM, on_exit)
 
-    parker_enabled = config.get_config().parker.enabled
+    worker_config = config.get_config()
+    parker_enabled = worker_config.parker.enabled
     if parker_enabled:
         logger.info("Parker mode is enabled")
     else:
-        domains = config.get_config().domains
-        prefixes = config.get_config().domain_prefixes
+        domains = worker_config.domains
+        prefixes = worker_config.domain_prefixes
         if not domains:
             raise DomainsNotInConfig("Could not locate domains in configuration.")
         if not check_all_domains_unique(domains, prefixes):
@@ -151,9 +201,19 @@ def main():
             if not is_valid_domain(domain):
                 raise InvalidDomain(f"Domain {domain} has invalid prefix.")
 
-    clean_up_worker(parker_enabled)
-    watch_queue(parker_enabled)
-    mqtt.connect(exit_event)
+    cleanup_threads = clean_up_worker(parker_enabled, exit_event, worker_config)
+    queue_thread = watch_queue(
+        parker_enabled,
+        exit_event,
+        parker_prefix_length=worker_config.parker.prefixes.ipv6.length,
+        initial_handshake_grace=worker_config.cleanup.initial_handshake_grace,
+    )
+    try:
+        mqtt.connect(exit_event)
+    finally:
+        exit_event.set()
+        for thread in [queue_thread, *cleanup_threads]:
+            thread.join()
 
 
 if __name__ == "__main__":

--- a/wgkex/worker/app_test.py
+++ b/wgkex/worker/app_test.py
@@ -1,147 +1,121 @@
-"""Unit tests for app.py"""
+"""Unit tests for the worker application lifecycle."""
 
 import threading
 import unittest
-from time import sleep
 
 import mock
 
+from wgkex.config import config
 from wgkex.worker import app
 
 
-def _get_config_mock(domains=None, parker=None):
+def _get_config_mock(domains=None, parker_enabled=False):
     test_prefixes = ["_TEST_PREFIX_", "_TEST_PREFIX2_"]
-    config_mock = mock.MagicMock()
-    if parker:
-        config_mock.parker = parker
-    else:
-        config_mock.parker.enabled = False
-    config_mock.domains = (
+    worker_config = mock.MagicMock()
+    worker_config.parker.enabled = parker_enabled
+    worker_config.parker.prefixes.ipv6.length = 63
+    worker_config.cleanup = config.Cleanup(interval=0.01)
+    worker_config.domains = (
         domains if domains is not None else [f"{test_prefixes[1]}domain.one"]
     )
-    config_mock.domain_prefixes = test_prefixes
-    return config_mock
+    worker_config.domain_prefixes = test_prefixes
+    return worker_config
 
 
 class AppTest(unittest.TestCase):
-    """unittest.TestCase class"""
-
-    def setUp(self) -> None:
-        """set up unittests"""
-        app._CLEANUP_TIME = 0
-
     def test_unique_domains_success(self):
-        """Ensure domain suffixes are unique."""
-        test_prefixes = ["TEST_PREFIX_", "TEST_PREFIX2_"]
-        test_domains = [
-            "TEST_PREFIX_DOMAINSUFFIX1",
-            "TEST_PREFIX_DOMAINSUFFIX2",
-            "TEST_PREFIX2_DOMAINSUFFIX3",
-        ]
         self.assertTrue(
-            app.check_all_domains_unique(test_domains, test_prefixes),
-            "unique domains are not detected unique",
+            app.check_all_domains_unique(
+                ["TEST_PREFIX_ONE", "TEST_PREFIX2_TWO"],
+                ["TEST_PREFIX_", "TEST_PREFIX2_"],
+            )
         )
 
     def test_unique_domains_fail(self):
-        """Ensure domain suffixes are not unique."""
-        test_prefixes = ["TEST_PREFIX_", "TEST_PREFIX2_"]
-        test_domains = [
-            "TEST_PREFIX_DOMAINSUFFIX1",
-            "TEST_PREFIX_DOMAINSUFFIX2",
-            "TEST_PREFIX2_DOMAINSUFFIX1",
-        ]
         self.assertFalse(
-            app.check_all_domains_unique(test_domains, test_prefixes),
-            "non-unique domains are detected as unique",
+            app.check_all_domains_unique(
+                ["TEST_PREFIX_SAME", "TEST_PREFIX2_SAME"],
+                ["TEST_PREFIX_", "TEST_PREFIX2_"],
+            )
         )
 
-    def test_unique_domains_not_list(self):
-        """Ensure domain prefixes are a list."""
-        test_prefixes = "TEST_PREFIX_, TEST_PREFIX2_"
-        test_domains = [
-            "TEST_PREFIX_DOMAINSUFFIX1",
-            "TEST_PREFIX_DOMAINSUFFIX2",
-            "TEST_PREFIX2_DOMAINSUFFIX1",
-        ]
+    def test_unique_domains_validates_prefixes(self):
         with self.assertRaises(TypeError):
-            app.check_all_domains_unique(test_domains, test_prefixes)
+            app.check_all_domains_unique(["TEST_PREFIX_ONE"], "TEST_PREFIX_")
+        with self.assertRaises(app.PrefixesNotInConfig):
+            app.check_all_domains_unique(["TEST_PREFIX_ONE"], [])
 
-    @mock.patch.object(app.config, "get_config")
-    @mock.patch.object(app.mqtt, "connect", autospec=True)
-    def test_main_success(self, connect_mock, config_mock):
-        """Ensure we can execute main."""
-        connect_mock.return_value = None
-        config_mock.return_value = _get_config_mock()
-        with mock.patch.object(app, "flush_workers", return_value=None):
-            app.main()
-            connect_mock.assert_called()
-
-    @mock.patch.object(app.config, "get_config")
-    @mock.patch.object(app.mqtt, "connect", autospec=True)
-    def test_main_fails_no_domain(self, connect_mock, config_mock):
-        """Ensure we fail when domains are not configured."""
-        config_mock.return_value = _get_config_mock(domains=[])
-        connect_mock.return_value = None
-        with self.assertRaises(app.DomainsNotInConfig):
-            app.main()
-
-    @mock.patch.object(app.config, "get_config")
-    @mock.patch.object(app.mqtt, "connect", autospec=True)
-    def test_main_fails_bad_domain(self, connect_mock, config_mock):
-        """Ensure we fail when domains are badly formatted."""
-        config_mock.return_value = _get_config_mock(domains=["cant_split_domain"])
-        connect_mock.return_value = None
-        with self.assertRaises(app.InvalidDomain):
-            app.main()
-        connect_mock.assert_not_called()
-
-    @mock.patch.object(app, "_CLEANUP_TIME", 1)
     @mock.patch.object(app, "wg_flush_stale_peers")
-    def test_flush_workers_doesnt_throw(self, wg_flush_mock):
-        """Ensure the flush_workers thread doesn't throw and exit if it encounters an exception."""
-        wg_flush_mock.side_effect = AttributeError(
-            "'NoneType' object has no attribute 'get'"
+    def test_flush_workers_uses_configured_timing_and_stops(self, flush):
+        flush.return_value = [
+            mock.Mock(status="deleted"),
+            mock.Mock(status="deferred"),
+            mock.Mock(status="failed"),
+        ]
+        exit_event = mock.MagicMock()
+        exit_event.wait.side_effect = [False, True]
+        cleanup = config.Cleanup(
+            interval=12,
+            parker_stale_timeout=345,
+            initial_handshake_grace=678,
         )
 
+        app.flush_workers(exit_event, True, "parker", cleanup, 62)
+
+        self.assertEqual(exit_event.wait.call_args_list, [mock.call(12), mock.call(12)])
+        flush.assert_called_once_with(
+            True,
+            "parker",
+            stale_timeout=345,
+            initial_handshake_grace=678,
+            parker_prefix_length=62,
+            coordinator=mock.ANY,
+        )
+
+    @mock.patch.object(
+        app, "wg_flush_stale_peers", side_effect=[RuntimeError("dump failed"), []]
+    )
+    def test_flush_workers_retries_next_sweep(self, flush):
+        exit_event = mock.MagicMock()
+        exit_event.wait.side_effect = [False, False, True]
+
+        app.flush_workers(exit_event, False, "domain", config.Cleanup(interval=1))
+
+        self.assertEqual(flush.call_count, 2)
+
+    def test_flush_workers_shutdown_interrupts_wait(self):
+        exit_event = threading.Event()
         thread = threading.Thread(
-            target=app.flush_workers, args=(False, "dummy_domain"), daemon=True
+            target=app.flush_workers,
+            args=(
+                exit_event,
+                False,
+                "domain",
+                config.Cleanup(interval=3600),
+            ),
         )
         thread.start()
-
-        i = 0
-        while i < 20 and not wg_flush_mock.called:
-            i += 1
-            sleep(0.1)
-
-        wg_flush_mock.assert_called()
-        # Assert that the thread hasn't crashed and is still running
-        self.assertTrue(thread.is_alive())
-        # If Python would allow it without writing custom signalling, this would be the place to stop the thread again
+        exit_event.set()
+        thread.join(timeout=1)
+        self.assertFalse(thread.is_alive())
 
     @mock.patch.object(app.threading, "Thread")
     def test_cleanup_schedules_parker_and_legacy_domains(self, thread):
-        app.clean_up_worker(True)
-        thread.assert_called_once_with(
-            target=app.flush_workers, args=(True, "parker"), daemon=True
-        )
+        parker_config = _get_config_mock(parker_enabled=True)
+        exit_event = threading.Event()
+        threads = app.clean_up_worker(True, exit_event, parker_config)
+        self.assertEqual(threads, [thread.return_value])
+        self.assertEqual(thread.call_args.kwargs["name"], "peer-cleanup-parker")
         thread.return_value.start.assert_called_once()
 
         thread.reset_mock()
-        with (
-            mock.patch.object(
-                app.config,
-                "get_config",
-                return_value=_get_config_mock(
-                    domains=["_TEST_PREFIX_domain.one", "unmatched"]
-                ),
-            ),
-            mock.patch.object(app.logger, "error") as error,
-        ):
-            app.clean_up_worker(False)
-        thread.assert_called_once_with(
-            target=app.flush_workers, args=(False, "domain.one"), daemon=True
+        legacy_config = _get_config_mock(
+            domains=["_TEST_PREFIX_domain.one", "unmatched"]
         )
+        with mock.patch.object(app.logger, "error") as error:
+            threads = app.clean_up_worker(False, exit_event, legacy_config)
+        self.assertEqual(threads, [thread.return_value])
+        self.assertEqual(thread.call_args.kwargs["name"], "peer-cleanup-domain.one")
         thread.return_value.start.assert_called_once()
         error.assert_called_once_with(
             "Not every domain got cleaned. Check domains %s for missing prefixes %s",
@@ -150,8 +124,55 @@ class AppTest(unittest.TestCase):
         )
 
     @mock.patch.object(app.config, "get_config")
-    def test_main_parker_registers_shutdown_and_starts_components(self, config_mock):
-        config_mock.return_value = _get_config_mock(parker=mock.MagicMock(enabled=True))
+    @mock.patch.object(app.mqtt, "connect")
+    @mock.patch.object(app, "watch_queue")
+    @mock.patch.object(app, "clean_up_worker")
+    def test_main_starts_and_joins_worker_threads(
+        self, cleanup, watch_queue, connect, get_config
+    ):
+        worker_config = _get_config_mock(parker_enabled=True)
+        get_config.return_value = worker_config
+        cleanup_thread = mock.Mock()
+        queue_thread = mock.Mock()
+        cleanup.return_value = [cleanup_thread]
+        watch_queue.return_value = queue_thread
+
+        app.main()
+
+        exit_event = cleanup.call_args.args[1]
+        cleanup.assert_called_once_with(True, exit_event, worker_config)
+        watch_queue.assert_called_once_with(
+            True,
+            exit_event,
+            parker_prefix_length=63,
+            initial_handshake_grace=600,
+        )
+        connect.assert_called_once_with(exit_event)
+        self.assertTrue(exit_event.is_set())
+        queue_thread.join.assert_called_once()
+        cleanup_thread.join.assert_called_once()
+
+    @mock.patch.object(app.config, "get_config")
+    @mock.patch.object(app.mqtt, "connect")
+    def test_main_rejects_invalid_legacy_configuration(self, connect, get_config):
+        get_config.return_value = _get_config_mock(domains=[])
+        with self.assertRaises(app.DomainsNotInConfig):
+            app.main()
+        connect.assert_not_called()
+
+        get_config.return_value = _get_config_mock(
+            domains=["_TEST_PREFIX_same", "_TEST_PREFIX2_same"]
+        )
+        with self.assertRaises(app.DomainsAreNotUnique):
+            app.main()
+
+        get_config.return_value = _get_config_mock(domains=["cant_split_domain"])
+        with self.assertRaises(app.InvalidDomain):
+            app.main()
+
+    @mock.patch.object(app.config, "get_config")
+    def test_signal_sets_exit_event(self, get_config):
+        get_config.return_value = _get_config_mock(parker_enabled=True)
         callbacks = []
         with (
             mock.patch.object(
@@ -159,35 +180,15 @@ class AppTest(unittest.TestCase):
                 "signal",
                 side_effect=lambda _, callback: callbacks.append(callback),
             ),
-            mock.patch.object(app, "clean_up_worker") as cleanup,
-            mock.patch.object(app, "watch_queue") as watch_queue,
-            mock.patch.object(app.mqtt, "connect") as connect,
-        ):
-            app.main()
-
-        cleanup.assert_called_once_with(True)
-        watch_queue.assert_called_once_with(True)
-        connect.assert_called_once()
-        self.assertEqual(len(callbacks), 2)
-
-        with (
-            mock.patch.object(app.time, "sleep") as sleep,
+            mock.patch.object(app, "clean_up_worker", return_value=[]),
+            mock.patch.object(app, "watch_queue", return_value=mock.Mock()),
+            mock.patch.object(app.mqtt, "connect"),
             mock.patch.object(app.sys, "exit") as exit_process,
         ):
-            callbacks[0](app.signal.SIGINT, None)
-        sleep.assert_called_once_with(2)
-        exit_process.assert_called_once()
-
-    @mock.patch.object(app.config, "get_config")
-    def test_main_rejects_duplicate_stripped_domains(self, config_mock):
-        config_mock.return_value = _get_config_mock(
-            domains=["_TEST_PREFIX_same", "_TEST_PREFIX2_same"]
-        )
-        with (
-            mock.patch.object(app.signal, "signal"),
-            self.assertRaises(app.DomainsAreNotUnique),
-        ):
             app.main()
+            callbacks[0](app.signal.SIGINT, None)
+
+        exit_process.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/wgkex/worker/msg_queue.py
+++ b/wgkex/worker/msg_queue.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 import json
 import threading
+from ipaddress import IPv6Network
 from queue import Empty, Queue
 
 from wgkex.common import logger
 from wgkex.worker.netlink import (
+    get_parker_prefixes_for_peer,
     ParkerWireGuardClient,
+    PeerMutationError,
     WireGuardClient,
     link_handler,
 )
+from wgkex.worker.peer_state import PeerMutationCoordinator, peer_mutations
 
 
 class UniqueQueue(Queue):
@@ -29,21 +33,64 @@ class UniqueQueue(Queue):
 q = UniqueQueue()
 
 
-def watch_queue(parker: bool = False) -> None:
+def watch_queue(
+    parker: bool,
+    stop_event: threading.Event,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    parker_prefix_length: int = 63,
+    initial_handshake_grace: float = 600,
+) -> threading.Thread:
     """Watches the queue for new messages."""
     logger.debug("Starting queue watcher")
-    threading.Thread(target=pick_from_queue, args=[parker], daemon=True).start()
+    thread = threading.Thread(
+        target=pick_from_queue,
+        args=(
+            parker,
+            q,
+            stop_event,
+            coordinator,
+            parker_prefix_length,
+            initial_handshake_grace,
+        ),
+        name="peer-update-queue",
+    )
+    thread.start()
+    return thread
 
 
-def _process_queue_item(item, parker: bool) -> None:
+def _process_queue_item(
+    item,
+    parker: bool,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    parker_prefix_length: int = 63,
+    initial_handshake_grace: float = 600,
+) -> None:
     if parker:
         message = json.loads(item)
+        if not isinstance(message, dict):
+            raise ValueError("Parker queue item must be an object")
+        public_key = message.get("PublicKey")
+        range6 = message.get("Range6")
+        if not isinstance(public_key, str) or not public_key:
+            raise ValueError("Parker queue item has no valid PublicKey")
+        try:
+            parsed_range6 = IPv6Network(range6)
+        except (TypeError, ValueError) as error:
+            raise ValueError("Parker queue item has no valid Range6") from error
+        if parsed_range6.prefixlen != parker_prefix_length:
+            raise ValueError(
+                "Parker queue item Range6 prefix length "
+                f"must be /{parker_prefix_length}"
+            )
+        previous_ranges6 = tuple(
+            get_parker_prefixes_for_peer("wg-nodes", public_key, parker_prefix_length)
+        )
         client = ParkerWireGuardClient(
-            # TODO use shared data class
-            public_key=message.get("PublicKey"),
-            range6=message.get("Range6"),
+            public_key=public_key,
+            range6=str(parsed_range6),
             keepalive=message.get("Keepalive"),
             remove=False,
+            previous_ranges6=previous_ranges6,
         )
         logger.info(
             "Processing queue for key %s with range %s",
@@ -52,6 +99,13 @@ def _process_queue_item(item, parker: bool) -> None:
         )
     else:
         domain, message = item
+        if (
+            not isinstance(domain, str)
+            or not domain
+            or not isinstance(message, str)
+            or not message
+        ):
+            raise ValueError("Legacy queue item has no valid domain or public key")
         logger.debug("Processing queue item %s for domain %s", message, domain)
         client = WireGuardClient(
             public_key=message,
@@ -64,13 +118,33 @@ def _process_queue_item(item, parker: bool) -> None:
             domain,
             client.lladdr,
         )
-    logger.debug(link_handler(client))
+    related_resources = (
+        [client.range6, *client.previous_ranges6]
+        if isinstance(client, ParkerWireGuardClient)
+        else None
+    )
+    with coordinator.peer_lock(client.public_key, related_resources):
+        coordinator.record_provisioned(client.public_key, initial_handshake_grace)
+        try:
+            result = link_handler(client)
+        except PeerMutationError as error:
+            if error.operation == "wireguard" and not error.operations:
+                coordinator.forget(client.public_key)
+            if error.operation.startswith("old_route:"):
+                coordinator.record_pending_parker_route(
+                    error.operation.removeprefix("old_route:")
+                )
+            raise
+        logger.debug(result)
 
 
 def pick_from_queue(
     parker: bool = False,
     work_queue: Queue = q,
     stop_event: threading.Event | None = None,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    parker_prefix_length: int = 63,
+    initial_handshake_grace: float = 600,
 ) -> None:
     """Picks a message from the queue and processes it."""
     logger.debug("Starting queue processor")
@@ -81,7 +155,13 @@ def pick_from_queue(
             continue
 
         try:
-            _process_queue_item(item, parker)
+            _process_queue_item(
+                item,
+                parker,
+                coordinator,
+                parker_prefix_length,
+                initial_handshake_grace,
+            )
         except Exception as error:
             logger.error(
                 "Failed to process queue item %r; continuing with the next item",

--- a/wgkex/worker/msg_queue_test.py
+++ b/wgkex/worker/msg_queue_test.py
@@ -7,9 +7,26 @@ from queue import Queue
 import mock
 
 from wgkex.worker import msg_queue
+from wgkex.worker import netlink
+from wgkex.worker.peer_state import PeerMutationCoordinator
+
+
+class MutableClock:
+    def __init__(self):
+        self.now = 0
+
+    def __call__(self):
+        return self.now
 
 
 class TestMessageQueue(unittest.TestCase):
+    def setUp(self):
+        self.prefixes = mock.patch.object(
+            msg_queue, "get_parker_prefixes_for_peer", return_value=[]
+        )
+        self.get_prefixes = self.prefixes.start()
+        self.addCleanup(self.prefixes.stop)
+
     @mock.patch.object(msg_queue, "link_handler")
     def test_bad_item_does_not_stop_processing_or_break_accounting(self, link_handler):
         work_queue = Queue()
@@ -70,6 +87,142 @@ class TestMessageQueue(unittest.TestCase):
         self.assertEqual(work_queue.unfinished_tasks, 0)
         self.assertEqual(link_handler.call_count, 2)
         self.assertEqual(link_handler.call_args.args[0].public_key, "second-key")
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_accepted_updates_refresh_provisioning_state(self, link_handler):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        msg_queue._process_queue_item(
+            json.dumps(
+                {
+                    "PublicKey": "key",
+                    "Range6": "2001:db8::/63",
+                    "Keepalive": 25,
+                }
+            ),
+            True,
+            coordinator,
+        )
+        self.assertTrue(coordinator.recently_provisioned("key", 600))
+        link_handler.assert_called_once()
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_parker_update_carries_and_locks_previous_prefixes(self, link_handler):
+        self.get_prefixes.return_value = ["2001:db8:1::/63"]
+        coordinator = mock.MagicMock()
+        coordinator.peer_lock.return_value.__enter__.return_value = None
+
+        msg_queue._process_queue_item(
+            json.dumps(
+                {
+                    "PublicKey": "key",
+                    "Range6": "2001:db8:2::/63",
+                    "Keepalive": 25,
+                }
+            ),
+            True,
+            coordinator,
+        )
+
+        client = link_handler.call_args.args[0]
+        self.assertEqual(client.previous_ranges6, ("2001:db8:1::/63",))
+        coordinator.peer_lock.assert_called_once_with(
+            "key", ["2001:db8:2::/63", "2001:db8:1::/63"]
+        )
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_malformed_queue_items_are_rejected(self, link_handler):
+        invalid_items = (
+            ("[]", True),
+            ('{"PublicKey":"","Range6":"2001:db8::/63"}', True),
+            ('{"PublicKey":"key","Range6":"invalid"}', True),
+            ('{"PublicKey":"key","Range6":"2001:db8::/64"}', True),
+            (("", "key"), False),
+            (("domain", ""), False),
+        )
+        for item, parker in invalid_items:
+            with self.subTest(item=item), self.assertRaises(ValueError):
+                msg_queue._process_queue_item(item, parker)
+        link_handler.assert_not_called()
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_failed_old_route_is_queued_for_cleanup(self, link_handler):
+        client = netlink.ParkerWireGuardClient("key", "2001:db8:2::/63", False)
+        link_handler.side_effect = netlink.PeerMutationError(
+            "old_route:2001:db8:1::/63",
+            client,
+            {
+                "wireguard": netlink.OperationOutcome("updated"),
+                "route": netlink.OperationOutcome("updated"),
+            },
+            RuntimeError("route failed"),
+        )
+        coordinator = PeerMutationCoordinator()
+
+        with self.assertRaises(netlink.PeerMutationError):
+            msg_queue._process_queue_item(
+                json.dumps(
+                    {
+                        "PublicKey": "key",
+                        "Range6": "2001:db8:2::/63",
+                    }
+                ),
+                True,
+                coordinator,
+            )
+
+        self.assertEqual(
+            coordinator.pending_parker_routes(),
+            ("2001:db8:1::/63",),
+        )
+
+    def test_concurrent_update_defers_cleanup_for_same_peer(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        update_entered = threading.Event()
+        release_update = threading.Event()
+        cleanup_results = []
+        stale = netlink.StaleWireGuardPeer("key", None, "stale_handshake")
+
+        def update_peer(_):
+            update_entered.set()
+            release_update.wait(timeout=1)
+            return {}
+
+        with (
+            mock.patch.object(msg_queue, "link_handler", side_effect=update_peer),
+            mock.patch.object(
+                netlink, "find_stale_wireguard_clients", return_value=[stale]
+            ),
+            mock.patch.object(netlink, "link_handler") as delete_peer,
+        ):
+            update_thread = threading.Thread(
+                target=msg_queue._process_queue_item,
+                args=(("domain", "key"), False, coordinator),
+            )
+            update_thread.start()
+            self.assertTrue(update_entered.wait(timeout=1))
+
+            cleanup_thread = threading.Thread(
+                target=lambda: cleanup_results.extend(
+                    netlink.wg_flush_stale_peers(
+                        False,
+                        "domain",
+                        initial_handshake_grace=600,
+                        coordinator=coordinator,
+                        clock=clock,
+                    )
+                )
+            )
+            cleanup_thread.start()
+            time.sleep(0.05)
+            delete_peer.assert_not_called()
+            release_update.set()
+            update_thread.join(timeout=1)
+            cleanup_thread.join(timeout=1)
+
+        self.assertEqual(cleanup_results[0].status, "deferred")
+        delete_peer.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -1,12 +1,15 @@
 """Functions related to netlink manipulation for Wireguard, IPRoute and FDB on Linux."""
 
 # See https://docs.pyroute2.org/iproute.html for a documentation of the layout of netlink responses
+import errno
 import hashlib
+import ipaddress
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from textwrap import wrap
-from typing import Dict, List, Optional, Tuple, Union
+from time import time
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pyroute2
 import pyroute2.netlink
@@ -14,8 +17,13 @@ import pyroute2.netlink.exceptions
 
 from wgkex.common import logger
 from wgkex.common.utils import mac2eui64
+from wgkex.worker.peer_state import PeerMutationCoordinator, peer_mutations
 
-_PEER_TIMEOUT_HOURS = 3
+_PARKER_STALE_TIMEOUT = 300
+_LEGACY_STALE_TIMEOUT = 10800
+_INITIAL_HANDSHAKE_GRACE = 600
+_NETLINK_DUMP_RETRIES = 1
+_ABSENT_ERRNOS = {errno.ENOENT, errno.ENODEV, errno.ESRCH}
 
 
 @dataclass
@@ -73,41 +81,225 @@ class ParkerWireGuardClient:
     range6: str
     remove: bool
     keepalive: Optional[int] = None
+    previous_ranges6: Tuple[str, ...] = ()
 
 
-def wg_flush_stale_peers(parker: bool = False, domain: str = "") -> List[Dict]:
+@dataclass(frozen=True)
+class StaleWireGuardPeer:
+    """A validated peer selected for cleanup."""
+
+    public_key: str
+    parker_prefix: Optional[str]
+    reason: str
+
+
+@dataclass(frozen=True)
+class OperationOutcome:
+    """The explicit outcome of one netlink mutation."""
+
+    status: str
+    result: Any = None
+
+
+@dataclass(frozen=True)
+class PeerCleanupResult:
+    """The explicit result of one stale peer cleanup attempt."""
+
+    public_key: str
+    status: str
+    operations: Dict[str, OperationOutcome]
+    failed_operation: Optional[str] = None
+    error: Optional[str] = None
+
+
+class PeerMutationError(RuntimeError):
+    """A peer mutation failed after zero or more successful operations."""
+
+    def __init__(
+        self,
+        operation: str,
+        client: Union[WireGuardClient, ParkerWireGuardClient],
+        operations: Dict[str, OperationOutcome],
+        cause: Exception,
+    ) -> None:
+        super().__init__(f"{operation} failed for peer {client.public_key}: {cause}")
+        self.operation = operation
+        self.client = client
+        self.operations = operations
+        self.cause = cause
+
+
+def wg_flush_stale_peers(
+    parker: bool = False,
+    domain: str = "",
+    *,
+    stale_timeout: Optional[float] = None,
+    initial_handshake_grace: float = _INITIAL_HANDSHAKE_GRACE,
+    parker_prefix_length: int = 63,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    clock: Callable[[], float] = time,
+) -> List[PeerCleanupResult]:
     """Removes stale peers.
 
     Arguments:
         domain: The domain to detect peers on.
 
     Returns:
-        The peers which we can remove.
+        The outcome for every peer selected for cleanup.
     """
+    if stale_timeout is None:
+        stale_timeout = _PARKER_STALE_TIMEOUT if parker else _LEGACY_STALE_TIMEOUT
     if parker:
-        logger.info("Searching for staleclients")
-        stale_clients = find_stale_wireguard_clients(parker, "wg-nodes")
+        retry_pending_parker_routes(
+            coordinator=coordinator,
+            prefix_length=parker_prefix_length,
+        )
+        wg_interface = "wg-nodes"
+        logger.info("Searching for stale clients interface=%s", wg_interface)
+        stale_clients = find_stale_wireguard_clients(
+            parker,
+            wg_interface,
+            stale_timeout=stale_timeout,
+            initial_handshake_grace=initial_handshake_grace,
+            parker_prefix_length=parker_prefix_length,
+            coordinator=coordinator,
+            clock=clock,
+        )
         logger.debug("Found %s stale clients: %s", len(stale_clients), stale_clients)
         stale_wireguard_clients = [
-            ParkerWireGuardClient(public_key=stale_client, range6=range6, remove=True)
-            for (stale_client, range6) in stale_clients
+            ParkerWireGuardClient(
+                public_key=stale_client.public_key,
+                range6=stale_client.parker_prefix or "",
+                remove=True,
+            )
+            for stale_client in stale_clients
         ]
     else:
-        logger.info("Searching for stale clients for %s", domain)
-        stale_clients = find_stale_wireguard_clients(parker, "wg-" + domain)
+        wg_interface = "wg-" + domain
+        logger.info(
+            "Searching for stale clients interface=%s domain=%s",
+            wg_interface,
+            domain,
+        )
+        stale_clients = find_stale_wireguard_clients(
+            parker,
+            wg_interface,
+            stale_timeout=stale_timeout,
+            initial_handshake_grace=initial_handshake_grace,
+            coordinator=coordinator,
+            clock=clock,
+        )
         logger.debug("Found %s stale clients: %s", len(stale_clients), stale_clients)
         stale_wireguard_clients = [
-            WireGuardClient(public_key=stale_client, domain=domain, remove=True)
-            for (stale_client, _) in stale_clients
+            WireGuardClient(
+                public_key=stale_client.public_key,
+                domain=domain,
+                remove=True,
+            )
+            for stale_client in stale_clients
         ]
 
-    logger.debug("Found stale WireGuard clients: %s", stale_wireguard_clients)
-    logger.info("Processing stale WireGuard clients.")
-    link_handled = [
-        link_handler(stale_client) for stale_client in stale_wireguard_clients
-    ]
-    logger.debug("Handled the following stale clients: %s", link_handled)
-    return link_handled
+    results = []
+    for client in stale_wireguard_clients:
+        related_resource = (
+            client.range6 if isinstance(client, ParkerWireGuardClient) else None
+        )
+        with coordinator.peer_lock(client.public_key, related_resource):
+            if coordinator.recently_provisioned(
+                client.public_key, initial_handshake_grace
+            ):
+                logger.info(
+                    "Deferring cleanup for recently provisioned peer "
+                    "interface=%s public_key=%s",
+                    wg_interface,
+                    client.public_key,
+                )
+                results.append(
+                    PeerCleanupResult(
+                        public_key=client.public_key,
+                        status="deferred",
+                        operations={},
+                    )
+                )
+                continue
+            current_stale_peers = find_stale_wireguard_clients(
+                parker,
+                wg_interface,
+                stale_timeout=stale_timeout,
+                initial_handshake_grace=initial_handshake_grace,
+                parker_prefix_length=parker_prefix_length,
+                coordinator=coordinator,
+                clock=clock,
+            )
+            still_stale = any(
+                stale_peer.public_key == client.public_key
+                and (not parker or stale_peer.parker_prefix == related_resource)
+                for stale_peer in current_stale_peers
+            )
+            if not still_stale:
+                logger.info(
+                    "Deferring cleanup after peer state changed "
+                    "interface=%s public_key=%s",
+                    wg_interface,
+                    client.public_key,
+                )
+                results.append(
+                    PeerCleanupResult(
+                        public_key=client.public_key,
+                        status="deferred",
+                        operations={},
+                    )
+                )
+                continue
+            try:
+                preserve_parker_route = isinstance(
+                    client, ParkerWireGuardClient
+                ) and parker_prefix_owned_by_other_peer(
+                    wg_interface,
+                    client.range6,
+                    client.public_key,
+                    parker_prefix_length,
+                )
+                operations = link_handler(
+                    client, preserve_parker_route=preserve_parker_route
+                )
+            except PeerMutationError as error:
+                logger.error(
+                    "Peer cleanup failed interface=%s public_key=%s "
+                    "operation=%s completed_operations=%s error=%s",
+                    wg_interface,
+                    client.public_key,
+                    error.operation,
+                    list(error.operations),
+                    error.cause,
+                    exc_info=error,
+                )
+                results.append(
+                    PeerCleanupResult(
+                        public_key=client.public_key,
+                        status="failed",
+                        operations=error.operations,
+                        failed_operation=error.operation,
+                        error=str(error.cause),
+                    )
+                )
+                continue
+
+            coordinator.forget(client.public_key)
+            logger.info(
+                "Peer cleanup completed interface=%s public_key=%s operations=%s",
+                wg_interface,
+                client.public_key,
+                {name: outcome.status for name, outcome in operations.items()},
+            )
+            results.append(
+                PeerCleanupResult(
+                    public_key=client.public_key,
+                    status="deleted",
+                    operations=operations,
+                )
+            )
+    return results
 
 
 ##################
@@ -115,7 +307,44 @@ def wg_flush_stale_peers(parker: bool = False, domain: str = "") -> List[Dict]:
 ##################
 
 
-def link_handler(client: Union[WireGuardClient, ParkerWireGuardClient]) -> Dict:
+def _is_absent_error(error: Exception) -> bool:
+    code = getattr(error, "code", None)
+    return isinstance(code, int) and abs(code) in _ABSENT_ERRNOS
+
+
+def _run_operation(
+    operation: str,
+    client: Union[WireGuardClient, ParkerWireGuardClient],
+    handler: Callable[[Union[WireGuardClient, ParkerWireGuardClient]], Dict],
+    operations: Dict[str, OperationOutcome],
+) -> None:
+    try:
+        result = handler(client)
+    except pyroute2.netlink.exceptions.NetlinkError as error:
+        if client.remove and _is_absent_error(error):
+            logger.info(
+                "Peer cleanup dependency already absent public_key=%s "
+                "operation=%s errno=%s",
+                client.public_key,
+                operation,
+                error.code,
+            )
+            operations[operation] = OperationOutcome(status="already_absent")
+            return
+        raise PeerMutationError(operation, client, operations.copy(), error) from error
+    except Exception as error:
+        raise PeerMutationError(operation, client, operations.copy(), error) from error
+    operations[operation] = OperationOutcome(
+        status="deleted" if client.remove else "updated",
+        result=result,
+    )
+
+
+def link_handler(
+    client: Union[WireGuardClient, ParkerWireGuardClient],
+    *,
+    preserve_parker_route: bool = False,
+) -> Dict[str, OperationOutcome]:
     """Updates fdb, route and WireGuard peers tables for a given WireGuard peer.
 
     Arguments:
@@ -123,23 +352,44 @@ def link_handler(client: Union[WireGuardClient, ParkerWireGuardClient]) -> Dict:
     Returns:
         The outcome of each operation.
     """
-    results = dict()
-    # Updates WireGuard peers.
-    results.update({"Wireguard": update_wireguard_peer(client)})
+    operations: Dict[str, OperationOutcome] = {}
     logger.debug("Handling links for %s", client)
-    try:
-        # Updates routes to the WireGuard Peer.
-        results.update({"Route": route_handler(client)})
-        logger.info("Updated route for %s", client)
-    except Exception as e:
-        # TODO(ruairi): re-raise exception here.
-        logger.error("Failed to update route for %s (%s)", client, e)
-        results.update({"Route": e})
-    if isinstance(client, WireGuardClient):
-        # Updates WireGuard FDB.
-        results.update({"Bridge FDB": bridge_fdb_handler(client)})
-        logger.debug("Updated Bridge FDB for %s", client)
-    return results
+    if client.remove:
+        # Keep the peer discoverable until every dependent object is gone.
+        if isinstance(client, WireGuardClient):
+            _run_operation("bridge_fdb", client, bridge_fdb_handler, operations)
+        if preserve_parker_route:
+            logger.info(
+                "Preserving Parker route owned by another peer "
+                "public_key=%s prefix=%s",
+                client.public_key,
+                client.range6,
+            )
+            operations["route"] = OperationOutcome(status="preserved_shared")
+        else:
+            _run_operation("route", client, route_handler, operations)
+        _run_operation("wireguard", client, update_wireguard_peer, operations)
+    else:
+        _run_operation("wireguard", client, update_wireguard_peer, operations)
+        _run_operation("route", client, route_handler, operations)
+        if isinstance(client, ParkerWireGuardClient):
+            for previous_range6 in client.previous_ranges6:
+                if previous_range6 == client.range6:
+                    continue
+                previous_client = ParkerWireGuardClient(
+                    public_key=client.public_key,
+                    range6=previous_range6,
+                    remove=True,
+                )
+                _run_operation(
+                    f"old_route:{previous_range6}",
+                    previous_client,
+                    route_handler,
+                    operations,
+                )
+        if isinstance(client, WireGuardClient):
+            _run_operation("bridge_fdb", client, bridge_fdb_handler, operations)
+    return operations
 
 
 def bridge_fdb_handler(client: WireGuardClient) -> Dict:
@@ -229,7 +479,214 @@ def route_handler(client: Union[WireGuardClient, ParkerWireGuardClient]) -> Dict
         return dict(result) if isinstance(result, dict) else {"result": result}
 
 
-def find_stale_wireguard_clients(parker: bool, wg_interface: str) -> List:
+def _wireguard_info(
+    wg: pyroute2.WireGuard,
+    wg_interface: str,
+    retries: int = _NETLINK_DUMP_RETRIES,
+) -> List:
+    for attempt in range(retries + 1):
+        try:
+            return wg.info(wg_interface)
+        except pyroute2.netlink.exceptions.NetlinkDumpInterrupted:
+            if attempt == retries:
+                raise
+            logger.warning(
+                "WireGuard netlink dump interrupted; retrying "
+                "interface=%s attempt=%s max_attempts=%s",
+                wg_interface,
+                attempt + 1,
+                retries + 1,
+            )
+    raise AssertionError("unreachable")
+
+
+def _peer_public_key(peer: pyroute2.netlink.nla) -> str:
+    public_key = peer.get_attr("WGPEER_A_PUBLIC_KEY")
+    if isinstance(public_key, bytes):
+        public_key = public_key.decode("ascii")
+    if not isinstance(public_key, str) or not public_key:
+        raise ValueError("missing or invalid public key")
+    return public_key
+
+
+def _last_handshake_seconds(peer: pyroute2.netlink.nla) -> Optional[int]:
+    handshake = peer.get_attr("WGPEER_A_LAST_HANDSHAKE_TIME")
+    if handshake is None:
+        return None
+    if not isinstance(handshake, dict):
+        raise ValueError("invalid last handshake attribute")
+    seconds = handshake.get("tv_sec")
+    if isinstance(seconds, bool) or not isinstance(seconds, int) or seconds < 0:
+        raise ValueError("invalid last handshake seconds")
+    return seconds
+
+
+def _parker_prefix(peer: pyroute2.netlink.nla, prefix_length: int) -> str:
+    allowed_ips = peer.get_attr("WGPEER_A_ALLOWEDIPS")
+    if not isinstance(allowed_ips, (list, tuple)):
+        raise ValueError("missing or invalid allowed IPs")
+
+    matches = set()
+    for allowed_ip in allowed_ips:
+        address = allowed_ip.get("addr") if isinstance(allowed_ip, dict) else None
+        if not isinstance(address, str):
+            continue
+        try:
+            network = ipaddress.ip_network(address, strict=False)
+        except ValueError:
+            continue
+        if network.version == 6 and network.prefixlen == prefix_length:
+            matches.add(str(network))
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one IPv6 /{prefix_length} Parker prefix, "
+            f"found {len(matches)}"
+        )
+    return matches.pop()
+
+
+def parker_prefix_owned_by_other_peer(
+    wg_interface: str,
+    parker_prefix: str,
+    public_key: str,
+    prefix_length: int,
+) -> bool:
+    """Return whether another current peer owns a Parker prefix."""
+    with pyroute2.WireGuard() as wg:
+        messages = _wireguard_info(wg, wg_interface)
+    for message in messages:
+        peers = message.get_attr("WGDEVICE_A_PEERS")
+        if not isinstance(peers, (list, tuple)):
+            continue
+        for peer in peers:
+            try:
+                peer_prefix = _parker_prefix(peer, prefix_length)
+            except (ValueError, AttributeError):
+                continue
+            if peer_prefix != parker_prefix:
+                continue
+            try:
+                peer_public_key = _peer_public_key(peer)
+            except (UnicodeDecodeError, ValueError, AttributeError):
+                logger.warning(
+                    "Preserving Parker route with ambiguous owner "
+                    "interface=%s prefix=%s",
+                    wg_interface,
+                    parker_prefix,
+                )
+                return True
+            if peer_public_key != public_key:
+                return True
+    return False
+
+
+def retry_pending_parker_routes(
+    *,
+    coordinator: PeerMutationCoordinator,
+    prefix_length: int,
+    wg_interface: str = "wg-nodes",
+) -> None:
+    """Retry old Parker route deletions left by partial queue updates."""
+    for prefix in coordinator.pending_parker_routes():
+        with coordinator.peer_lock("", prefix):
+            try:
+                has_owner = parker_prefix_owned_by_other_peer(
+                    wg_interface, prefix, "", prefix_length
+                )
+            except pyroute2.netlink.exceptions.NetlinkDumpInterrupted as error:
+                logger.warning(
+                    "Pending Parker route ownership check failed "
+                    "interface=%s prefix=%s error=%s",
+                    wg_interface,
+                    prefix,
+                    error,
+                )
+                continue
+            if has_owner:
+                logger.info(
+                    "Pending Parker route is owned again; preserving "
+                    "interface=%s prefix=%s",
+                    wg_interface,
+                    prefix,
+                )
+                coordinator.forget_pending_parker_route(prefix)
+                continue
+
+            operations: Dict[str, OperationOutcome] = {}
+            client = ParkerWireGuardClient(
+                public_key="pending-route-cleanup",
+                range6=prefix,
+                remove=True,
+            )
+            try:
+                _run_operation("route", client, route_handler, operations)
+            except PeerMutationError as error:
+                logger.error(
+                    "Pending Parker route cleanup failed "
+                    "interface=%s prefix=%s error=%s",
+                    wg_interface,
+                    prefix,
+                    error.cause,
+                    exc_info=error,
+                )
+                continue
+            coordinator.forget_pending_parker_route(prefix)
+            logger.info(
+                "Pending Parker route cleanup completed "
+                "interface=%s prefix=%s status=%s",
+                wg_interface,
+                prefix,
+                operations["route"].status,
+            )
+
+
+def get_parker_prefixes_for_peer(
+    wg_interface: str,
+    public_key: str,
+    prefix_length: int,
+) -> List[str]:
+    """Return all assigned Parker prefixes currently owned by a peer."""
+    with pyroute2.WireGuard() as wg:
+        messages = _wireguard_info(wg, wg_interface)
+    prefixes = set()
+    for message in messages:
+        peers = message.get_attr("WGDEVICE_A_PEERS")
+        if not isinstance(peers, (list, tuple)):
+            continue
+        for peer in peers:
+            try:
+                if _peer_public_key(peer) != public_key:
+                    continue
+                allowed_ips = peer.get_attr("WGPEER_A_ALLOWEDIPS")
+            except (UnicodeDecodeError, ValueError, AttributeError):
+                continue
+            if not isinstance(allowed_ips, (list, tuple)):
+                continue
+            for allowed_ip in allowed_ips:
+                address = (
+                    allowed_ip.get("addr") if isinstance(allowed_ip, dict) else None
+                )
+                if not isinstance(address, str):
+                    continue
+                try:
+                    network = ipaddress.ip_network(address, strict=False)
+                except ValueError:
+                    continue
+                if network.version == 6 and network.prefixlen == prefix_length:
+                    prefixes.add(str(network))
+    return sorted(prefixes)
+
+
+def find_stale_wireguard_clients(
+    parker: bool,
+    wg_interface: str,
+    *,
+    stale_timeout: Optional[float] = None,
+    initial_handshake_grace: float = _INITIAL_HANDSHAKE_GRACE,
+    parker_prefix_length: int = 63,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    clock: Callable[[], float] = time,
+) -> List[StaleWireGuardPeer]:
     """Fetches and returns a list of peers which have not had recent handshakes.
 
     Arguments:
@@ -238,38 +695,67 @@ def find_stale_wireguard_clients(parker: bool, wg_interface: str) -> List:
     Returns:
         # A list of peers which have not recently seen a handshake.
     """
-    three_hrs_in_secs = int(
-        (datetime.now() - timedelta(hours=_PEER_TIMEOUT_HOURS)).timestamp()
-    )
-    five_mins_in_secs = int((datetime.now() - timedelta(minutes=5)).timestamp())
+    if stale_timeout is None:
+        stale_timeout = _PARKER_STALE_TIMEOUT if parker else _LEGACY_STALE_TIMEOUT
+    now = clock()
+    stale_before = now - stale_timeout
     logger.info(
         "Starting search for stale wireguard peers for interface %s.", wg_interface
     )
     with pyroute2.WireGuard() as wg:
         all_peers = []
-        msgs = wg.info(wg_interface)
+        msgs = _wireguard_info(wg, wg_interface)
         logger.debug("Got infos for stale peers: %s.", msgs)
         for msg in msgs:
             peers = msg.get_attr("WGDEVICE_A_PEERS")
-            logger.debug("Got clients: %s.", peers)
+            if peers is not None and not isinstance(peers, (list, tuple)):
+                logger.warning(
+                    "Skipping malformed WireGuard peer list interface=%s",
+                    wg_interface,
+                )
+                continue
             if peers:
                 all_peers.extend(peers)
 
-        ret = [
-            (
-                peer.get_attr("WGPEER_A_PUBLIC_KEY").decode("utf-8"),
-                (
-                    allowed_ips[0].get("addr")  # addr contains the prefix as string
-                    if parker and (allowed_ips := peer.get_attr("WGPEER_A_ALLOWEDIPS"))
-                    else None
-                ),
+        stale_peers = []
+        for peer_index, peer in enumerate(all_peers):
+            try:
+                public_key = _peer_public_key(peer)
+                last_handshake = _last_handshake_seconds(peer)
+                if coordinator.recently_provisioned(
+                    public_key, initial_handshake_grace
+                ):
+                    continue
+                if last_handshake in (None, 0):
+                    if coordinator.defer_never_handshaked(
+                        public_key, initial_handshake_grace
+                    ):
+                        continue
+                    reason = "never_handshaked"
+                elif last_handshake <= stale_before:
+                    reason = "stale_handshake"
+                else:
+                    continue
+                parker_prefix = (
+                    _parker_prefix(peer, parker_prefix_length) if parker else None
+                )
+            except (UnicodeDecodeError, ValueError, AttributeError) as error:
+                logger.warning(
+                    "Skipping malformed WireGuard peer interface=%s "
+                    "peer_index=%s reason=%s",
+                    wg_interface,
+                    peer_index,
+                    error,
+                )
+                continue
+            stale_peers.append(
+                StaleWireGuardPeer(
+                    public_key=public_key,
+                    parker_prefix=parker_prefix,
+                    reason=reason,
+                )
             )
-            for peer in all_peers
-            if (hshk_time := peer.get_attr("WGPEER_A_LAST_HANDSHAKE_TIME")) is not None
-            and hshk_time.get("tv_sec", int())
-            < (five_mins_in_secs if parker else three_hrs_in_secs)
-        ]
-        return ret
+        return stale_peers
 
 
 def get_connected_peers_count(wg_interface: str) -> int:
@@ -287,13 +773,7 @@ def get_connected_peers_count(wg_interface: str) -> int:
     three_mins_ago_in_secs = int((datetime.now() - timedelta(minutes=3)).timestamp())
     logger.info("Counting connected wireguard peers for interface %s.", wg_interface)
     with pyroute2.WireGuard() as wg:
-        try:
-            msgs = wg.info(wg_interface)
-        except pyroute2.netlink.exceptions.NetlinkDumpInterrupted:
-            # Normal behaviour, data has changed while it was being returned by netlink.
-            # Retry once, don't catch the exception this time, and let the caller handle it.
-            # See https://github.com/svinota/pyroute2/issues/874
-            msgs = wg.info(wg_interface)
+        msgs = _wireguard_info(wg, wg_interface)
 
         logger.debug("Got infos for connected peers: %s.", msgs)
         count = 0

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -1,7 +1,6 @@
-"""Unit tests for netlink.py"""
+"""Behavioral tests for worker netlink cleanup."""
 
-# pyroute2 decides imports based on platform. WireGuard is specific to Linux only. Mock pyroute2.WireGuard so that
-# any testing platform can execute tests.
+import errno
 import importlib
 import sys
 import unittest
@@ -18,316 +17,493 @@ from pyroute2 import IPRoute, WireGuard  # noqa: E402
 
 sys.modules.pop("wgkex.worker.netlink", None)
 netlink = importlib.import_module("wgkex.worker.netlink")
-
-_WG_CLIENT_ADD = netlink.WireGuardClient(
-    public_key="public_key", domain="add", remove=False
-)
-_WG_CLIENT_DEL = netlink.WireGuardClient(
-    public_key="public_key", domain="del", remove=True
-)
+from wgkex.worker.peer_state import PeerMutationCoordinator  # noqa: E402
 
 
-def _get_peer_mock(public_key, last_handshake_time, has_allowed_ips=True):
-    def peer_get_attr(attr: str):
-        if attr == "WGPEER_A_LAST_HANDSHAKE_TIME":
-            return {"tv_sec": last_handshake_time}
-        if attr == "WGPEER_A_PUBLIC_KEY":
-            return public_key.encode()
-        if attr == "WGPEER_A_ALLOWEDIPS":
-            if not has_allowed_ips:
-                return None
-            return [
-                {
-                    "attrs": [
-                        ("WGALLOWEDIP_A_CIDR_MASK", 63),
-                        ("WGALLOWEDIP_A_FAMILY", 10),
-                        (
-                            "WGALLOWEDIP_A_IPADDR",
-                            "20:01:0d:b8:0e:d0:00:0a:00:00:00:00:00:00:00:00",
-                        ),
-                    ],
-                    "addr": "2001:db8:ed0:a::/63",
-                }
-            ]
+class MutableClock:
+    def __init__(self, now=100_000):
+        self.now = now
 
-    peer_mock = mock.Mock()
-    peer_mock.get_attr.side_effect = peer_get_attr
-    return peer_mock
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
 
 
-def _get_wg_mock(public_key, last_handshake_time, has_allowed_ips=True):
-    peer_mock = _get_peer_mock(public_key, last_handshake_time, has_allowed_ips)
+_DEFAULT_ALLOWED_IPS = object()
 
-    def msg_get_attr(attr: str):
-        if attr == "WGDEVICE_A_PEERS":
-            return [peer_mock]
 
-    msg_mock = mock.Mock()
-    msg_mock.get_attr.side_effect = msg_get_attr
-    wg_instance = WireGuard()
-    wg_info_mock = wg_instance.__enter__.return_value
-    wg_info_mock.set.return_value = {"WireGuard": "set"}
-    wg_info_mock.info.return_value = [msg_mock]
-    return wg_info_mock
+def _peer(
+    public_key="key",
+    handshake=100_000,
+    allowed_ips=_DEFAULT_ALLOWED_IPS,
+):
+    attrs = {
+        "WGPEER_A_PUBLIC_KEY": (
+            public_key.encode("ascii") if isinstance(public_key, str) else public_key
+        ),
+        "WGPEER_A_LAST_HANDSHAKE_TIME": (
+            {"tv_sec": handshake} if handshake is not None else None
+        ),
+        "WGPEER_A_ALLOWEDIPS": (
+            [{"addr": "2001:db8:1::/63"}]
+            if allowed_ips is _DEFAULT_ALLOWED_IPS
+            else allowed_ips
+        ),
+    }
+    peer = mock.Mock()
+    peer.get_attr.side_effect = attrs.get
+    return peer
+
+
+def _message(peers):
+    message = mock.Mock()
+    message.get_attr.side_effect = {
+        "WGDEVICE_A_PEERS": peers,
+        "WGDEVICE_A_LISTEN_PORT": 51820,
+        "WGDEVICE_A_PUBLIC_KEY": b"device-key",
+    }.get
+    return message
 
 
 class NetlinkTest(unittest.TestCase):
-    def setUp(self) -> None:
-        iproute_instance = IPRoute()
-        self.route_info_mock = iproute_instance.__enter__.return_value
-        # self.addCleanup(mock.patch.stopall)
+    def setUp(self):
+        self.wg = WireGuard().__enter__.return_value
+        self.wg.reset_mock()
+        self.wg.info.side_effect = None
+        self.ip = IPRoute().__enter__.return_value
+        self.ip.reset_mock()
+        self.ip.link_lookup.return_value = [7]
 
-    def test_find_stale_wireguard_clients_success_with_non_stale_peer(self):
-        """Tests find_stale_wireguard_clients no operation on non-stale peers."""
-        _wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        self.assertListEqual(
-            [], netlink.find_stale_wireguard_clients(False, "some_interface")
-        )
-
-    def test_find_stale_wireguard_clients_success_stale_peer(self):
-        """Tests find_stale_wireguard_clients removal of stale peer"""
-        _wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY_STALE",
-            int((datetime.now() - timedelta(hours=5)).timestamp()),
-        )
-        self.assertListEqual(
-            [("WGPEER_A_PUBLIC_KEY_STALE", None)],
-            netlink.find_stale_wireguard_clients(False, "some_interface"),
+    def _find(self, peers, parker=False, clock=None, coordinator=None, **kwargs):
+        clock = clock or MutableClock()
+        coordinator = coordinator or PeerMutationCoordinator(clock=clock)
+        self.wg.info.return_value = [_message(peers)]
+        return netlink.find_stale_wireguard_clients(
+            parker,
+            "wg-nodes" if parker else "wg-domain",
+            coordinator=coordinator,
+            clock=clock,
+            **kwargs,
         )
 
-    def test_stale_parker_peer_without_allowed_ips_does_not_abort_search(self):
-        _get_wg_mock(
-            "PARKER_PUBLIC_KEY",
-            int((datetime.now() - timedelta(hours=1)).timestamp()),
-            has_allowed_ips=False,
+    def test_handshake_cutoff_is_inclusive_and_mode_specific(self):
+        clock = MutableClock()
+        parker = self._find(
+            [
+                _peer("recent", clock.now - 299),
+                _peer("boundary", clock.now - 300),
+            ],
+            parker=True,
+            clock=clock,
+            stale_timeout=300,
+        )
+        self.assertEqual([peer.public_key for peer in parker], ["boundary"])
+
+        legacy = self._find(
+            [
+                _peer("recent", clock.now - 10799),
+                _peer("boundary", clock.now - 10800),
+            ],
+            clock=clock,
+            stale_timeout=10800,
+        )
+        self.assertEqual([peer.public_key for peer in legacy], ["boundary"])
+
+    def test_never_handshaked_peers_get_grace_then_become_stale(self):
+        for handshake in (0, None):
+            with self.subTest(handshake=handshake):
+                clock = MutableClock()
+                coordinator = PeerMutationCoordinator(clock=clock)
+                peers = [_peer("never", handshake)]
+                self.assertEqual(
+                    self._find(
+                        peers,
+                        clock=clock,
+                        coordinator=coordinator,
+                        initial_handshake_grace=600,
+                    ),
+                    [],
+                )
+                clock.advance(600)
+                result = self._find(
+                    peers,
+                    clock=clock,
+                    coordinator=coordinator,
+                    initial_handshake_grace=600,
+                )
+                self.assertEqual(result[0].reason, "never_handshaked")
+
+    def test_recent_queue_update_refreshes_grace_for_stale_peer(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        coordinator.record_provisioned("key")
+        peers = [_peer("key", clock.now - 1000)]
+
+        clock.advance(599)
+        self.assertEqual(
+            self._find(
+                peers,
+                parker=True,
+                clock=clock,
+                coordinator=coordinator,
+                stale_timeout=300,
+                initial_handshake_grace=600,
+            ),
+            [],
+        )
+        clock.advance(1)
+        self.assertEqual(
+            self._find(
+                peers,
+                parker=True,
+                clock=clock,
+                coordinator=coordinator,
+                stale_timeout=300,
+                initial_handshake_grace=600,
+            )[0].public_key,
+            "key",
         )
 
-        self.assertListEqual(
-            [("PARKER_PUBLIC_KEY", None)],
-            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
+    def test_parker_prefix_is_selected_from_all_allowed_ips(self):
+        result = self._find(
+            [
+                _peer(
+                    "key",
+                    1,
+                    [
+                        {"addr": "fe80::1/128"},
+                        {"addr": "192.0.2.1/32"},
+                        {"addr": "2001:db8:20::1/63"},
+                    ],
+                )
+            ],
+            parker=True,
+            stale_timeout=300,
+        )
+        self.assertEqual(result[0].parker_prefix, "2001:db8:20::/63")
+
+    def test_malformed_peers_are_skipped_without_aborting_sweep(self):
+        malformed_handshake = _peer("bad-handshake", 1)
+        malformed_handshake.get_attr.side_effect = {
+            "WGPEER_A_PUBLIC_KEY": b"bad-handshake",
+            "WGPEER_A_LAST_HANDSHAKE_TIME": {"tv_sec": "old"},
+        }.get
+        result = self._find(
+            [
+                _peer(None, 1),
+                malformed_handshake,
+                _peer(
+                    "ambiguous",
+                    1,
+                    [
+                        {"addr": "2001:db8:1::/63"},
+                        {"addr": "2001:db8:2::/63"},
+                    ],
+                ),
+                _peer("valid", 1),
+            ],
+            parker=True,
+            stale_timeout=300,
+        )
+        self.assertEqual([peer.public_key for peer in result], ["valid"])
+
+    def test_stale_parker_peer_without_allowed_ips_is_skipped(self):
+        result = self._find(
+            [
+                _peer("without-allowed-ips", 1, None),
+                _peer("valid", 1),
+            ],
+            parker=True,
+            stale_timeout=300,
+        )
+        self.assertEqual([peer.public_key for peer in result], ["valid"])
+
+    def test_netlink_dump_interruption_retries_once(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        self.wg.info.side_effect = [
+            pyroute2_netlink_exceptions.NetlinkDumpInterrupted(),
+            [_message([_peer("key", 1)])],
+        ]
+        result = netlink.find_stale_wireguard_clients(
+            False,
+            "wg-domain",
+            stale_timeout=300,
+            coordinator=coordinator,
+            clock=clock,
+        )
+        self.assertEqual(result[0].public_key, "key")
+        self.assertEqual(self.wg.info.call_count, 2)
+
+        self.wg.info.reset_mock()
+        self.wg.info.side_effect = pyroute2_netlink_exceptions.NetlinkDumpInterrupted()
+        with self.assertRaises(pyroute2_netlink_exceptions.NetlinkDumpInterrupted):
+            netlink.find_stale_wireguard_clients(
+                False,
+                "wg-domain",
+                coordinator=coordinator,
+                clock=clock,
+            )
+        self.assertEqual(self.wg.info.call_count, 2)
+
+    def test_parker_and_legacy_deletion_order(self):
+        for client, expected in (
+            (
+                netlink.ParkerWireGuardClient("key", "2001:db8::/63", True),
+                ["route", "wireguard"],
+            ),
+            (
+                netlink.WireGuardClient("key", "domain", True),
+                ["bridge_fdb", "route", "wireguard"],
+            ),
+        ):
+            calls = []
+            with (
+                mock.patch.object(
+                    netlink,
+                    "bridge_fdb_handler",
+                    side_effect=lambda _: calls.append("bridge_fdb") or {},
+                ),
+                mock.patch.object(
+                    netlink,
+                    "route_handler",
+                    side_effect=lambda _: calls.append("route") or {},
+                ),
+                mock.patch.object(
+                    netlink,
+                    "update_wireguard_peer",
+                    side_effect=lambda _: calls.append("wireguard") or {},
+                ),
+            ):
+                outcomes = netlink.link_handler(client)
+            self.assertEqual(calls, expected)
+            self.assertEqual(list(outcomes), expected)
+            self.assertTrue(
+                all(outcome.status == "deleted" for outcome in outcomes.values())
+            )
+
+    def test_parker_shared_prefix_preserves_route(self):
+        client = netlink.ParkerWireGuardClient("stale", "2001:db8::/63", True)
+        with (
+            mock.patch.object(netlink, "route_handler") as route,
+            mock.patch.object(netlink, "update_wireguard_peer", return_value={}),
+        ):
+            outcomes = netlink.link_handler(client, preserve_parker_route=True)
+        route.assert_not_called()
+        self.assertEqual(outcomes["route"].status, "preserved_shared")
+        self.assertEqual(outcomes["wireguard"].status, "deleted")
+
+    def test_parker_reassignment_removes_old_route_after_new_route(self):
+        client = netlink.ParkerWireGuardClient(
+            "key",
+            "2001:db8:2::/63",
+            False,
+            previous_ranges6=("2001:db8:1::/63",),
+        )
+        calls = []
+
+        def route_handler(route_client):
+            calls.append(
+                (
+                    "delete" if route_client.remove else "replace",
+                    route_client.range6,
+                )
+            )
+            return {}
+
+        with (
+            mock.patch.object(
+                netlink,
+                "update_wireguard_peer",
+                side_effect=lambda _: calls.append(("wireguard", None)) or {},
+            ),
+            mock.patch.object(netlink, "route_handler", side_effect=route_handler),
+        ):
+            outcomes = netlink.link_handler(client)
+
+        self.assertEqual(
+            calls,
+            [
+                ("wireguard", None),
+                ("replace", "2001:db8:2::/63"),
+                ("delete", "2001:db8:1::/63"),
+            ],
+        )
+        self.assertEqual(outcomes["old_route:2001:db8:1::/63"].status, "deleted")
+
+    def test_parker_prefix_ownership_checks_all_current_peers(self):
+        self.wg.info.return_value = [
+            _message(
+                [
+                    _peer(
+                        "stale",
+                        1,
+                        [{"addr": "2001:db8:20::/63"}],
+                    ),
+                    _peer(
+                        "active",
+                        100_000,
+                        [{"addr": "2001:db8:20::/63"}],
+                    ),
+                ]
+            )
+        ]
+        self.assertTrue(
+            netlink.parker_prefix_owned_by_other_peer(
+                "wg-nodes", "2001:db8:20::/63", "stale", 63
+            )
         )
 
-    def test_route_handler_add_success(self):
-        """Test route_handler for normal add operation."""
-        self.route_info_mock.route.return_value = {"key": "value"}
-        self.assertDictEqual({"key": "value"}, netlink.route_handler(_WG_CLIENT_ADD))
-        self.route_info_mock.route.assert_called_with(
-            "replace", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
+    def test_current_parker_prefixes_are_discovered_for_update(self):
+        self.wg.info.return_value = [
+            _message(
+                [
+                    _peer(
+                        "other",
+                        1,
+                        [{"addr": "2001:db8:10::/63"}],
+                    ),
+                    _peer(
+                        "key",
+                        1,
+                        [
+                            {"addr": "fe80::1/128"},
+                            {"addr": "2001:db8:20::1/63"},
+                        ],
+                    ),
+                ]
+            )
+        ]
+        self.assertEqual(
+            netlink.get_parker_prefixes_for_peer("wg-nodes", "key", 63),
+            ["2001:db8:20::/63"],
         )
 
-    def test_route_handler_remove_success(self):
-        """Test route_handler for normal del operation."""
-        self.route_info_mock.route.return_value = {"key": "value"}
-        self.assertDictEqual({"key": "value"}, netlink.route_handler(_WG_CLIENT_DEL))
-        self.route_info_mock.route.assert_called_with(
-            "del", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
-        )
+    def test_partial_failure_stops_before_peer_and_is_explicit(self):
+        client = netlink.WireGuardClient("key", "domain", True)
+        with (
+            mock.patch.object(netlink, "bridge_fdb_handler", return_value={}),
+            mock.patch.object(
+                netlink, "route_handler", side_effect=RuntimeError("route failed")
+            ),
+            mock.patch.object(netlink, "update_wireguard_peer") as remove_peer,
+            self.assertRaises(netlink.PeerMutationError) as raised,
+        ):
+            netlink.link_handler(client)
 
-    def test_update_wireguard_peer_success(self):
-        """Test update_wireguard_peer for normal operation."""
-        wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        self.assertDictEqual(
-            {"WireGuard": "set"}, netlink.update_wireguard_peer(_WG_CLIENT_ADD)
-        )
-        wg_info_mock.set.assert_called_with(
-            interface="wg-add",
-            peer={
-                "public_key": "public_key",
-                "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
-                "remove": False,
-            },
-        )
+        self.assertEqual(raised.exception.operation, "route")
+        self.assertEqual(list(raised.exception.operations), ["bridge_fdb"])
+        remove_peer.assert_not_called()
 
-    def test_bridge_fdb_handler_append_success(self):
-        """Test bridge_fdb_handler for normal append operation."""
-        self.route_info_mock.fdb.return_value = {"key": "value"}
-        self.assertEqual({"key": "value"}, netlink.bridge_fdb_handler(_WG_CLIENT_ADD))
-        self.route_info_mock.fdb.assert_called_with(
-            "append",
-            lladdr="00:00:00:00:00:00",
-            dst="fe80::282:6eff:fe9d:ecd3",
-            ifindex=mock.ANY,
-            NDA_IFINDEX=mock.ANY,
-        )
+    def test_already_absent_dependency_is_idempotent(self):
+        client = netlink.ParkerWireGuardClient("key", "2001:db8::/63", True)
+        absent = pyroute2_netlink_exceptions.NetlinkError(errno.ENOENT)
+        with (
+            mock.patch.object(netlink, "route_handler", side_effect=absent),
+            mock.patch.object(netlink, "update_wireguard_peer", return_value={}),
+        ):
+            outcomes = netlink.link_handler(client)
+        self.assertEqual(outcomes["route"].status, "already_absent")
+        self.assertEqual(outcomes["wireguard"].status, "deleted")
 
-    def test_bridge_fdb_handler_del_success(self):
-        """Test bridge_fdb_handler for normal del operation."""
-        self.route_info_mock.fdb.return_value = {"key": "value"}
-        self.assertEqual({"key": "value"}, netlink.bridge_fdb_handler(_WG_CLIENT_DEL))
-        self.route_info_mock.fdb.assert_called_with(
+    def test_failed_cleanup_is_selected_again_on_next_sweep(self):
+        stale = netlink.StaleWireGuardPeer("key", "2001:db8::/63", "stale")
+        client = netlink.ParkerWireGuardClient("key", "2001:db8::/63", True)
+        failure = netlink.PeerMutationError("route", client, {}, RuntimeError("failed"))
+        with (
+            mock.patch.object(
+                netlink, "find_stale_wireguard_clients", return_value=[stale]
+            ) as find,
+            mock.patch.object(
+                netlink,
+                "link_handler",
+                side_effect=[
+                    failure,
+                    {
+                        "route": netlink.OperationOutcome("deleted"),
+                        "wireguard": netlink.OperationOutcome("deleted"),
+                    },
+                ],
+            ),
+        ):
+            first = netlink.wg_flush_stale_peers(True)
+            second = netlink.wg_flush_stale_peers(True)
+
+        self.assertEqual(first[0].status, "failed")
+        self.assertEqual(first[0].failed_operation, "route")
+        self.assertEqual(second[0].status, "deleted")
+        self.assertEqual(find.call_count, 4)
+
+    def test_peer_that_becomes_active_after_scan_is_deferred(self):
+        stale = netlink.StaleWireGuardPeer("key", None, "stale")
+        with (
+            mock.patch.object(
+                netlink,
+                "find_stale_wireguard_clients",
+                side_effect=[[stale], []],
+            ),
+            mock.patch.object(netlink, "link_handler") as delete_peer,
+        ):
+            result = netlink.wg_flush_stale_peers(False, "domain")
+        self.assertEqual(result[0].status, "deferred")
+        delete_peer.assert_not_called()
+
+    def test_pending_old_parker_route_is_retried(self):
+        coordinator = PeerMutationCoordinator()
+        coordinator.record_pending_parker_route("2001:db8:1::/63")
+        with (
+            mock.patch.object(
+                netlink,
+                "parker_prefix_owned_by_other_peer",
+                return_value=False,
+            ),
+            mock.patch.object(netlink, "route_handler", return_value={}) as route,
+        ):
+            netlink.retry_pending_parker_routes(
+                coordinator=coordinator, prefix_length=63
+            )
+        route.assert_called_once()
+        self.assertEqual(coordinator.pending_parker_routes(), ())
+
+    def test_route_fdb_and_wireguard_handlers(self):
+        legacy = netlink.WireGuardClient("public_key", "domain", True)
+        self.ip.route.return_value = {"route": "deleted"}
+        self.ip.fdb.return_value = {"fdb": "deleted"}
+        self.wg.set.return_value = {"peer": "deleted"}
+
+        self.assertEqual(netlink.route_handler(legacy), {"route": "deleted"})
+        self.assertEqual(netlink.bridge_fdb_handler(legacy), {"fdb": "deleted"})
+        self.assertEqual(netlink.update_wireguard_peer(legacy), {"peer": "deleted"})
+        self.ip.route.assert_called_with("del", dst=legacy.lladdr, oif=mock.ANY)
+        self.ip.fdb.assert_called_with(
             "del",
             ifindex=mock.ANY,
-            NDA_IFINDEX=mock.ANY,
             lladdr="00:00:00:00:00:00",
-            dst="fe80::282:6eff:fe9d:ecd3",
-        )
-
-    def test_link_handler_addition_success(self):
-        """Test link_handler for normal operation."""
-        expected = {
-            "Wireguard": {"WireGuard": "set"},
-            "Route": {"IPRoute": "route"},
-            "Bridge FDB": {"IPRoute": "fdb"},
-        }
-        wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        wg_info_mock.set.return_value = {"WireGuard": "set"}
-        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
-        self.route_info_mock.route.return_value = {"IPRoute": "route"}
-        self.assertEqual(expected, netlink.link_handler(_WG_CLIENT_ADD))
-        self.route_info_mock.fdb.assert_called_with(
-            "append",
-            ifindex=mock.ANY,
+            dst=legacy.lladdr.removesuffix("/128"),
             NDA_IFINDEX=mock.ANY,
-            lladdr="00:00:00:00:00:00",
-            dst="fe80::282:6eff:fe9d:ecd3",
-        )
-        self.route_info_mock.route.assert_called_with(
-            "replace", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
-        )
-        wg_info_mock.set.assert_called_with(
-            interface="wg-add",
-            peer={
-                "public_key": "public_key",
-                "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
-                "remove": False,
-            },
         )
 
-    def test_wg_flush_stale_peers_not_stale_success(self):
-        """Tests processing of non-stale WireGuard Peer."""
-        _wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
-        self.route_info_mock.route.return_value = {"IPRoute": "route"}
-        self.assertListEqual([], netlink.wg_flush_stale_peers(False, "domain"))
-        # TODO(ruairi): Understand why pyroute.WireGuard.set
-        # wg_info_mock.set.assert_not_called()
-
-    def test_wg_flush_stale_peers_stale_success(self):
-        """Tests processing of stale WireGuard Peer."""
-        expected = [
-            {
-                "Wireguard": {"WireGuard": "set"},
-                "Route": {"IPRoute": "route"},
-                "Bridge FDB": {"IPRoute": "fdb"},
-            }
-        ]
-        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
-        self.route_info_mock.route.return_value = {"IPRoute": "route"}
-        wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY_STALE",
-            int((datetime.now() - timedelta(hours=5)).timestamp()),
-        )
-        wg_info_mock.set.return_value = {"WireGuard": "set"}
-        self.assertListEqual(expected, netlink.wg_flush_stale_peers(False, "domain"))
-        self.route_info_mock.route.assert_called_with(
-            "del", dst="fe80::281:16ff:fe49:395e/128", oif=mock.ANY
-        )
-
-    def test_get_connected_peers_count_success(self):
-        """Tests getting the correct number of connected peers for an interface."""
-        peers = []
-        for i in range(10):
-            peer_mock = _get_peer_mock(
-                "TEST_KEY",
-                int((datetime.now() - timedelta(minutes=i, seconds=5)).timestamp()),
+    def test_connected_count_and_device_data(self):
+        now = datetime.now()
+        peers = [
+            _peer(
+                f"key-{minutes}",
+                int((now - timedelta(minutes=minutes)).timestamp()),
             )
-            peers.append(peer_mock)
-
-        def msg_get_attr(attr: str):
-            if attr == "WGDEVICE_A_PEERS":
-                return peers
-
-        msg_mock = mock.Mock()
-        msg_mock.get_attr.side_effect = msg_get_attr
-
-        wg_instance = WireGuard()
-        wg_info_mock = wg_instance.__enter__.return_value
-        wg_info_mock.info.return_value = [msg_mock]
-
-        ret = netlink.get_connected_peers_count("wg-welt")
-        self.assertEqual(ret, 3)
-
-    @mock.patch("pyroute2.WireGuard")
-    def test_get_connected_peers_count_NetlinkDumpInterrupted(self, pyroute2_wg_mock):
-        """Tests getting the correct number of connected peers for an interface."""
-
-        nl_wg_mock_ctx = mock.MagicMock()
-        wg_info_mock = mock.MagicMock(
-            side_effect=(pyroute2_netlink_exceptions.NetlinkDumpInterrupted),
-        )
-        nl_wg_mock_ctx.info = wg_info_mock
-
-        nl_wg_mock_inst = pyroute2_wg_mock.return_value
-        nl_wg_mock_inst.__enter__ = mock.MagicMock(return_value=nl_wg_mock_ctx)
-
-        self.assertRaises(
-            pyroute2_netlink_exceptions.NetlinkDumpInterrupted,
-            netlink.get_connected_peers_count,
-            "wg-welt",
-        )
-        self.assertTrue(len(wg_info_mock.mock_calls) == 2)
-
-    def test_get_device_data_success(self):
-        def msg_get_attr(attr: str):
-            if attr == "WGDEVICE_A_LISTEN_PORT":
-                return 51820
-            if attr == "WGDEVICE_A_PUBLIC_KEY":
-                return "TEST_PUBLIC_KEY".encode("ascii")
-
-        msg_mock = mock.Mock()
-        msg_mock.get_attr.side_effect = msg_get_attr
-
-        wg_instance = WireGuard()
-        wg_info_mock = wg_instance.__enter__.return_value
-        wg_info_mock.info.return_value = [msg_mock]
-
-        ret = netlink.get_device_data("wg-welt")
-        self.assertTupleEqual(ret, (51820, "TEST_PUBLIC_KEY", mock.ANY))
-
-    def test_find_stale_wireguard_clients_parker_stale_peer(self):
-        """Tests find_stale_wireguard_clients in parker mode returning range6."""
-
-        _ = _get_wg_mock(
-            "PARKER_PUBLIC_KEY", int((datetime.now() - timedelta(hours=1)).timestamp())
-        )
-
-        self.assertListEqual(
-            [("PARKER_PUBLIC_KEY", "2001:db8:ed0:a::/63")],
-            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
-        )
-
-    def test_wg_flush_stale_peers_parker_stale_success(self):
-        """Tests processing of stale WireGuard Peer in parker mode."""
-
-        _ = _get_wg_mock(
-            "PARKER_PUBLIC_KEY", int((datetime.now() - timedelta(hours=1)).timestamp())
-        )
-
-        expected = [
-            {
-                "Wireguard": {"WireGuard": "set"},
-                "Route": {"IPRoute": "route"},
-            }
+            for minutes in range(5)
         ]
+        self.wg.info.return_value = [_message(peers)]
+        self.assertEqual(netlink.get_connected_peers_count("wg-domain"), 3)
 
-        ret = netlink.wg_flush_stale_peers(True, "parker")
-        self.assertListEqual(expected, ret)
-
-        # Verify the stale peer resulted in a route deletion for the parker range
-        self.route_info_mock.route.assert_called_with(
-            "del", dst="2001:db8:ed0:a::/63", oif=mock.ANY
+        self.ip.get_addr.return_value = [
+            mock.Mock(get_attr=mock.Mock(return_value="fe80::1"))
+        ]
+        self.wg.info.return_value = [_message([])]
+        self.assertEqual(
+            netlink.get_device_data("wg-domain"),
+            (51820, "device-key", "fe80::1"),
         )
 
 

--- a/wgkex/worker/peer_state.py
+++ b/wgkex/worker/peer_state.py
@@ -1,0 +1,127 @@
+"""Bounded worker-local state used to coordinate peer mutations."""
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Iterable
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+
+class PeerMutationCoordinator:
+    """Coordinates per-peer mutations and tracks recent provisioning."""
+
+    def __init__(
+        self,
+        clock: Callable[[], float] = time.monotonic,
+        lock_stripes: int = 256,
+        max_provisioned_peers: int = 65536,
+    ) -> None:
+        if lock_stripes <= 0:
+            raise ValueError("lock_stripes must be positive")
+        if max_provisioned_peers <= 0:
+            raise ValueError("max_provisioned_peers must be positive")
+
+        self._clock = clock
+        self._locks = tuple(threading.RLock() for _ in range(lock_stripes))
+        self._max_provisioned_peers = max_provisioned_peers
+        self._provisioned_at: OrderedDict[str, float] = OrderedDict()
+        self._pending_parker_routes: OrderedDict[str, None] = OrderedDict()
+        self._state_lock = threading.Lock()
+        self._started_at = clock()
+
+    @contextmanager
+    def peer_lock(
+        self,
+        public_key: str,
+        related_resources: str | Iterable[str] | None = None,
+    ) -> Iterator[None]:
+        """Lock a peer and optional related resources in stable order."""
+        resources = [f"peer:{public_key}"]
+        if isinstance(related_resources, str):
+            related_resources = [related_resources]
+        if related_resources is not None:
+            resources.extend(f"resource:{resource}" for resource in related_resources)
+        lock_indexes = sorted(
+            {hash(resource) % len(self._locks) for resource in resources}
+        )
+        locks = [self._locks[index] for index in lock_indexes]
+        for lock in locks:
+            lock.acquire()
+        try:
+            yield
+        finally:
+            for lock in reversed(locks):
+                lock.release()
+
+    def _prune_expired(self, now: float) -> None:
+        expired = [
+            public_key
+            for public_key, expires_at in self._provisioned_at.items()
+            if expires_at <= now
+        ]
+        for public_key in expired:
+            del self._provisioned_at[public_key]
+
+    def record_provisioned(
+        self, public_key: str, retention_seconds: float = 600
+    ) -> None:
+        """Record an accepted queue update before applying it to netlink."""
+        now = self._clock()
+        with self._state_lock:
+            self._prune_expired(now)
+            if public_key in self._provisioned_at:
+                del self._provisioned_at[public_key]
+            elif len(self._provisioned_at) >= self._max_provisioned_peers:
+                raise RuntimeError("recent peer provisioning tracker is at capacity")
+            self._provisioned_at[public_key] = now + retention_seconds
+
+    def recently_provisioned(self, public_key: str, grace_seconds: float) -> bool:
+        """Return whether a peer has a queue update inside the grace period."""
+        now = self._clock()
+        with self._state_lock:
+            expires_at = self._provisioned_at.get(public_key)
+            if expires_at is None:
+                return False
+            if now < expires_at:
+                return True
+            del self._provisioned_at[public_key]
+            return False
+
+    def defer_never_handshaked(self, public_key: str, grace_seconds: float) -> bool:
+        """Protect never-handshaked peers after provisioning or worker restart."""
+        now = self._clock()
+        with self._state_lock:
+            expires_at = self._provisioned_at.get(public_key)
+            if expires_at is not None and now < expires_at:
+                return True
+            self._provisioned_at.pop(public_key, None)
+            return now - self._started_at < grace_seconds
+
+    def forget(self, public_key: str) -> None:
+        """Forget state for a peer after it has been removed."""
+        with self._state_lock:
+            self._provisioned_at.pop(public_key, None)
+
+    def record_pending_parker_route(self, prefix: str) -> None:
+        """Remember an old Parker route that still needs deletion."""
+        with self._state_lock:
+            if prefix in self._pending_parker_routes:
+                self._pending_parker_routes.move_to_end(prefix)
+                return
+            if len(self._pending_parker_routes) >= self._max_provisioned_peers:
+                raise RuntimeError("pending Parker route tracker is at capacity")
+            self._pending_parker_routes[prefix] = None
+
+    def pending_parker_routes(self) -> tuple[str, ...]:
+        """Return a snapshot of old Parker routes awaiting deletion."""
+        with self._state_lock:
+            return tuple(self._pending_parker_routes)
+
+    def forget_pending_parker_route(self, prefix: str) -> None:
+        """Forget an old Parker route after deletion or reassignment."""
+        with self._state_lock:
+            self._pending_parker_routes.pop(prefix, None)
+
+
+peer_mutations = PeerMutationCoordinator()

--- a/wgkex/worker/peer_state_test.py
+++ b/wgkex/worker/peer_state_test.py
@@ -1,0 +1,107 @@
+"""Tests for bounded peer mutation state."""
+
+import threading
+import unittest
+
+from wgkex.worker.peer_state import PeerMutationCoordinator
+
+
+class MutableClock:
+    def __init__(self):
+        self.now = 0
+
+    def __call__(self):
+        return self.now
+
+
+class PeerMutationCoordinatorTest(unittest.TestCase):
+    def test_provisioning_and_restart_grace_expire(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        self.assertTrue(coordinator.defer_never_handshaked("unknown", 10))
+        coordinator.record_provisioned("known", 10)
+
+        clock.now = 9
+        self.assertTrue(coordinator.recently_provisioned("known", 10))
+        clock.now = 10
+        self.assertFalse(coordinator.recently_provisioned("known", 10))
+        self.assertFalse(coordinator.defer_never_handshaked("unknown", 10))
+
+    def test_tracker_capacity_is_bounded_and_explicit(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock, max_provisioned_peers=1)
+        coordinator.record_provisioned("first", 10)
+        with self.assertRaisesRegex(RuntimeError, "at capacity"):
+            coordinator.record_provisioned("second", 10)
+        self.assertTrue(coordinator.recently_provisioned("first", 10))
+        clock.now = 10
+        coordinator.record_provisioned("second", 10)
+        self.assertTrue(coordinator.recently_provisioned("second", 10))
+
+    def test_pending_parker_routes_are_bounded_and_removable(self):
+        coordinator = PeerMutationCoordinator(max_provisioned_peers=1)
+        coordinator.record_pending_parker_route("2001:db8:1::/63")
+        coordinator.record_pending_parker_route("2001:db8:1::/63")
+        with self.assertRaisesRegex(RuntimeError, "at capacity"):
+            coordinator.record_pending_parker_route("2001:db8:2::/63")
+        self.assertEqual(coordinator.pending_parker_routes(), ("2001:db8:1::/63",))
+        coordinator.forget_pending_parker_route("2001:db8:1::/63")
+        self.assertEqual(coordinator.pending_parker_routes(), ())
+
+    def test_same_peer_serializes_while_different_peers_do_not(self):
+        coordinator = PeerMutationCoordinator(lock_stripes=257)
+        entered = threading.Event()
+        release = threading.Event()
+        same_peer_entered = threading.Event()
+
+        def hold_lock():
+            with coordinator.peer_lock("peer"):
+                entered.set()
+                release.wait()
+
+        def wait_for_same_peer():
+            with coordinator.peer_lock("peer"):
+                same_peer_entered.set()
+
+        holder = threading.Thread(target=hold_lock)
+        waiter = threading.Thread(target=wait_for_same_peer)
+        holder.start()
+        entered.wait(timeout=1)
+        waiter.start()
+        self.assertFalse(same_peer_entered.wait(timeout=0.05))
+        with coordinator.peer_lock("other-peer"):
+            pass
+        release.set()
+        holder.join(timeout=1)
+        waiter.join(timeout=1)
+        self.assertTrue(same_peer_entered.is_set())
+
+    def test_related_resource_serializes_different_peers(self):
+        coordinator = PeerMutationCoordinator(lock_stripes=257)
+        entered = threading.Event()
+        release = threading.Event()
+        waiter_entered = threading.Event()
+
+        def hold_prefix():
+            with coordinator.peer_lock("old-key", "2001:db8::/63"):
+                entered.set()
+                release.wait()
+
+        def wait_for_prefix():
+            with coordinator.peer_lock("new-key", "2001:db8::/63"):
+                waiter_entered.set()
+
+        holder = threading.Thread(target=hold_prefix)
+        waiter = threading.Thread(target=wait_for_prefix)
+        holder.start()
+        entered.wait(timeout=1)
+        waiter.start()
+        self.assertFalse(waiter_entered.wait(timeout=0.05))
+        release.set()
+        holder.join(timeout=1)
+        waiter.join(timeout=1)
+        self.assertTrue(waiter_entered.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- define precise active, stale, and never-handshaked peer semantics with bounded worker-side provisioning state and restart grace
- make cleanup timing configurable, validated, interruptible, and synchronized with queue-driven mutations by peer and Parker prefix
- make Parker route and legacy FDB/route/peer deletion ordered, idempotent, observable, and retryable after partial failure
- harden WireGuard dumps and isolate malformed peers, including missing allowed IPs, bounded interrupted-dump retry, and safe Parker prefix selection across all allowed IPs
- add behavioral coverage for cutoffs, grace, malformed data, retries, races, lifecycle, deletion outcomes, and configuration

Follow-up to #202. This is the first of two stacked follow-up PRs and is based on #278 (`awlx-integrate-parker-new`). Broader production hardening is intentionally excluded.

## Cleanup semantics

A non-zero handshake is stale at the configured mode-specific cutoff (inclusive). Zero or missing handshakes receive the configured initial grace from an accepted queue update. Because WireGuard does not expose peer creation time, untracked never-handshaked peers receive one grace period from worker startup after restart, then become eligible for cleanup.

## Validation

- Bazel 9: all 15 test targets passed
- Bazel coverage: 3714/3802 lines (97.69%), 1290/1450 branches (88.97%)
- Bazel broker and worker builds passed
- Black 26.5.1 and Ruff passed
- Native repository Dockerfile built and inspected for linux/amd64

## Operational limitation

Provisioning and failed old-route retry state is intentionally worker-local and bounded. Restarted workers conservatively protect untracked never-handshaked peers for one grace period. The provisioning tracker caps at 65,536 live grace records and fails new provisioning explicitly at capacity rather than dropping safety state.