### PR TITLE
Safely integrate parker-new fixes into parker

### DIFF
--- a/PARKER.md
+++ b/PARKER.md
@@ -19,10 +19,40 @@ For Parker the following configuration items are relevant in addition to the def
 - `sticky_worker_tolerance`
 - `broker_signing_key`
 - `parker` section
+- `cleanup` section
 - `netbox` section
 
 
 ## Design considerations
+
+### Offline peer cleanup
+
+The Parker worker defaults to a 300-second stale-handshake timeout and a
+600-second initial-handshake grace. The stale timeout accommodates the default
+120-second config retry and 180-second WireGuard tunnel timeout. Zero or missing
+handshake timestamps mean that a peer has never handshaked; they do not cause
+immediate deletion. Accepted queue updates refresh an in-memory, bounded
+provisioning tracker, and cleanup serializes only with updates for the same
+public key or assigned prefix.
+
+WireGuard does not expose peer creation time. After a worker restart, every
+untracked never-handshaked peer therefore receives one grace period from worker
+startup. Truly abandoned peers are removed on a later sweep rather than retained
+forever. The tracker retains at most 65,536 peer timestamps; if that bound is
+reached before entries age out, new provisioning fails explicitly rather than
+dropping grace state and risking premature cleanup.
+
+For a stale Parker peer, cleanup removes the selected assigned-prefix route
+before removing the WireGuard peer. If another current peer owns the prefix, its
+route is preserved. A real route or peer failure is reported and retried on the
+next sweep; already-absent state is treated as idempotent.
+
+When an accepted queue update reassigns a peer, the worker locks both the old
+and new prefixes, installs the new peer state and route, then removes the old
+route. `Range6` must match the configured Parker IPv6 allocation prefix length.
+If old-route deletion fails after reassignment, the bounded worker-side tracker
+retries it on cleanup sweeps after checking that no current peer owns it. This
+prevents cleanup from preserving a route that the peer immediately abandons.
 
 ### Concentrator selection
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
     - [Backend worker](#backend-worker)
   - [Installation](#installation)
   - [Configuration](#configuration)
+    - [Worker peer cleanup](#worker-peer-cleanup)
   - [Development](#development)
     - [Build using Bazel](#build-using-bazel)
     - [Updating PIP dependencies for Bazel](#updating-pip-dependencies-for-bazel)
@@ -151,6 +152,29 @@ For further information, please see this [presentation on the architecture](http
 
 The `wgkex` configuration file defaults to `/etc/wgkex.yaml` ([Sample configuration file](wgkex.yaml.example)), however
 can also be overwritten by setting the environment variable `WGKEX_CONFIG_FILE`.
+
+### Worker peer cleanup
+
+Workers periodically remove offline WireGuard peers. A peer with a non-zero
+last-handshake timestamp is stale when its age is greater than or equal to the
+mode-specific timeout. A peer that has never handshaked is retained for
+`cleanup.initial_handshake_grace` after its most recent accepted queue update.
+After a worker restart, the kernel does not expose peer creation time, so all
+untracked never-handshaked peers receive one grace period starting at worker
+startup; abandoned peers are removed by the first later sweep.
+
+Cleanup scans do not block MQTT ingestion. Queue updates and cleanup serialize
+mutations for the same public key or Parker prefix. Parker deletion removes the
+assigned prefix route before the WireGuard peer, unless another current peer
+owns that prefix. Legacy deletion removes the FDB entry, then route, then peer.
+Already-absent dependencies are idempotent; other partial failures are reported
+and retried while the peer remains discoverable. Parker prefix reassignment
+locks both old and new prefixes and removes the old route after installing the
+new peer state and route; failed old-route deletion is retained and retried on
+later cleanup sweeps after an ownership check.
+
+See `wgkex.yaml.example` for the cleanup interval, Parker and legacy stale
+timeouts, and initial-handshake grace defaults.
 
 ## Development
 

--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -16,15 +16,23 @@ domain_prefixes:
 # [broker] The dict of workers mapping their hostname to their respective weight (for weighted peer distribution) and PoP (for multi-tunnel support, esp. in Parker)
 workers:
   gw04.in.ffmuc.net:
+    # A unique, static ID for this worker. In Parker mode it is the concentrator ID sent to
+    # nodes, identifying the tunnel on the node, so it must never change for a given worker.
+    # If omitted it defaults to the position in this map, which shifts when workers are
+    # added or removed - set it explicitly in production.
+    id: 1
     weight: 30
     pop: vie01
   gw05.in.ffmuc.net:
+    id: 2
     weight: 30
     pop: vie01
   gw06.in.ffmuc.net:
+    id: 3
     weight: 20
     pop: muc01
   gw07.in.ffmuc.net:
+    id: 4
     weight: 20
     pop: muc01
 # [broker] how much peers above the target value a worker may have (in percent rel. to the target value) to let clients stick to their current worker.

--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -42,6 +42,18 @@ workers:
 sticky_worker_tolerance: 15
 # [worker] The external hostname of this worker
 externalName: gw04.ext.ffmuc.net
+# [worker] Offline peer cleanup timing, in seconds. All values must be positive.
+cleanup:
+  # How often each WireGuard interface is scanned.
+  interval: 3600
+  # A Parker peer with an earlier last handshake is stale. The default allows
+  # multiple 120s config retries and the 180s WireGuard tunnel timeout.
+  parker_stale_timeout: 300
+  # Preserve the historical three-hour timeout for legacy peers.
+  legacy_stale_timeout: 10800
+  # Never-handshaked peers are retained this long after provisioning or worker
+  # startup, then treated as abandoned.
+  initial_handshake_grace: 600
 # [broker, worker]
 parker:
   # Enable Parker support. The broker will still handle non-Parker in the same instance, the worker however will disable non-Parker support in this case.

--- a/wgkex.yaml.example
+++ b/wgkex.yaml.example
@@ -18,8 +18,7 @@ workers:
   gw04.in.ffmuc.net:
     # A unique, static ID for this worker. In Parker mode it is the concentrator ID sent to
     # nodes, identifying the tunnel on the node, so it must never change for a given worker.
-    # If omitted it defaults to the position in this map, which shifts when workers are
-    # added or removed - set it explicitly in production.
+    # If omitted it defaults to the position in this map.
     id: 1
     weight: 30
     pop: vie01

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -332,13 +332,6 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
         domain, old_selected_concentrators
     )
 
-    ipam.update_prefix(
-        req_data.pubkey,
-        not config.get_config().parker.xlat,
-        True,
-        [w.name for w in selected_workers],
-    )
-
     if len(selected_workers) == 0:
         logger.error("No worker online for Parker network")
         if len(parker_worker_data) > 0:
@@ -395,6 +388,16 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
                 "id": worker.id,
             }
         )
+
+    # Persist the selection (and refresh last_allocated_on) only after a full
+    # concentrator list has been built, so a failed request doesn't overwrite
+    # the stored selection and break stickyness.
+    ipam.update_prefix(
+        req_data.pubkey,
+        not config.get_config().parker.xlat,
+        True,
+        [w.name for w in selected_workers],
+    )
 
     response = ParkerResponse(
         nonce=req_data.nonce,

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -105,7 +105,7 @@ def _load_parker_ipam() -> Optional[ParkerIPAM]:
             ipam = NetboxIPAM(
                 api_url=netbox_cfg.url,
                 token=netbox_cfg.api_key,
-                xlat=True,
+                xlat=config.get_config().parker.xlat,
             )
         case _:
             raise NotImplementedError(f"Invalid IPAM type {ipam_type}")

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -131,7 +131,7 @@ def get_active_brokers_count(parker: bool) -> int:
     zero and to be conservative when no announcements are available.
     """
     if parker:
-        c = len(parker_active_brokers)
+        c = len(active_brokers.intersection(parker_active_brokers))
     else:
         c = len(active_brokers)
     return max(c, 1)
@@ -333,14 +333,11 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
 
     if len(selected_workers) == 0:
         logger.error("No worker online for Parker network")
-        # Emergency mode - try to randomly select one for which we still have
-        # connection data cached. Only workers with a config entry qualify:
-        # the ID identifies the tunnel on the node, so it must be unique and
-        # stable, which requires an explicitly configured worker ID.
         fallback_candidates = [
             name
             for name in parker_worker_data
             if config.get_config().workers.get(name) is not None
+            and parker_worker_metrics.get(name).online
         ]
         if fallback_candidates:
             fallback_name = random.choice(fallback_candidates)
@@ -394,9 +391,6 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
             }
         )
 
-    # Persist the selection (and refresh last_allocated_on) only after a full
-    # concentrator list has been built, so a failed request doesn't overwrite
-    # the stored selection and break stickyness.
     ipam.update_prefix(
         req_data.pubkey,
         not config.get_config().parker.xlat,
@@ -482,19 +476,20 @@ def handle_mqtt_connect(
         parker_announce_topic = MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(
             broker=_HOSTNAME
         )
-        # Clear retained Parker announcements from older versions. The retained
-        # legacy status and its last will are the canonical liveness source.
-        mqtt.publish(
-            parker_announce_topic,
-            b"",
-            qos=1,
-            retain=True,
-        )
         mqtt.publish(
             parker_announce_topic,
             1,  # pyright: ignore[reportArgumentType]
             qos=1,
-            retain=False,
+            retain=True,
+        )
+    else:
+        # Clear capability left by an earlier Parker-enabled incarnation of
+        # this broker before advertising only its legacy liveness.
+        mqtt.publish(
+            MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(broker=_HOSTNAME),
+            b"",
+            qos=1,
+            retain=True,
         )
 
 
@@ -517,7 +512,7 @@ def handle_mqtt_message_metrics(
 
     try:
         data = int(message.payload)
-    except Exception:
+    except (TypeError, ValueError):
         logger.error(
             "Invalid metrics payload for %s/%s/%s: %s",
             worker,
@@ -547,7 +542,7 @@ def handle_mqtt_message_parker_metrics(
 
     try:
         data = int(message.payload)
-    except Exception:
+    except (TypeError, ValueError):
         logger.error(
             "Invalid metrics payload for %s/%s: %s", worker, metric, message.payload
         )
@@ -566,7 +561,7 @@ def handle_mqtt_message_status(
 
     try:
         status = int(message.payload)
-    except Exception:
+    except (TypeError, ValueError):
         logger.error(
             "Invalid worker status payload for %s: %s", worker, message.payload
         )
@@ -588,7 +583,7 @@ def handle_mqtt_message_parker_status(
 
     try:
         status = int(message.payload)
-    except Exception:
+    except (TypeError, ValueError):
         logger.error(
             "Invalid worker status payload for %s: %s", worker, message.payload
         )
@@ -668,18 +663,12 @@ def handle_mqtt_message_broker_status(
                 f"Broker marked online: {broker}, {len(active_brokers) + 1} brokers online"
             )
         active_brokers.add(broker)
-        # Parker membership is only added via the Parker alias announce:
-        # a broker announcing on the legacy topic is not necessarily
-        # Parker-capable (e.g. during a staged rollout).
     else:
         if broker in active_brokers:
             logger.info(
                 f"Broker marked offline: {broker}, {len(active_brokers) - 1} brokers online"
             )
             active_brokers.discard(broker)
-        # The retained legacy status and its last will are the canonical
-        # liveness source, so an offline announcement also clears the
-        # broker's Parker alias membership.
         if config.get_config().parker.enabled:
             parker_active_brokers.discard(broker)
 

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -329,21 +329,27 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
     domain = "parker"
 
     selected_workers = parker_worker_metrics.get_best_workers(
-        domain, old_selected_concentrators
+        domain, old_selected_concentrators, require_configured=True
     )
 
     if len(selected_workers) == 0:
         logger.error("No worker online for Parker network")
-        if len(parker_worker_data) > 0:
-            # Emergency mode - try to randomly select one for which we still have connection data cached
-            fallback_name = random.choice(list(parker_worker_data.keys()))
-            # Use the configured worker ID: the ID identifies the tunnel on the node,
-            # so it must not change depending on how the concentrator was selected
+        # Emergency mode - try to randomly select one for which we still have
+        # connection data cached. Only workers with a config entry qualify:
+        # the ID identifies the tunnel on the node, so it must be unique and
+        # stable, which requires an explicitly configured worker ID.
+        fallback_candidates = [
+            name
+            for name in parker_worker_data
+            if config.get_config().workers.get(name) is not None
+        ]
+        if fallback_candidates:
+            fallback_name = random.choice(fallback_candidates)
             fallback_cfg = config.get_config().workers.get(fallback_name)
             selected_workers.append(
                 WorkerResult(
                     name=fallback_name,
-                    id=fallback_cfg.id if fallback_cfg else 0,
+                    id=fallback_cfg.id,
                     diff=0,
                     peers=0,
                     target=0,

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -301,6 +301,16 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
                 "message": "Allocated IPv6 range is invalid. Please try again later."
             }
         }, 500
+    expected_length = config.get_config().parker.prefixes.ipv6.length
+    if full_range6.prefixlen != expected_length:
+        logger.warning(
+            "IPv6 prefix %s for public key %s has length /%s, but /%s is configured. "
+            "Fix or delete the prefix in the IPAM.",
+            full_range6,
+            req_data.pubkey,
+            full_range6.prefixlen,
+            expected_length,
+        )
     ranges = full_range6.subnets(new_prefix=64)
     range6 = next(ranges)
     xlat_range6 = next(ranges)

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -669,14 +669,18 @@ def handle_mqtt_message_broker_status(
                 f"Broker marked online: {broker}, {len(active_brokers) + 1} brokers online"
             )
         active_brokers.add(broker)
-        if config.get_config().parker.enabled:
-            parker_active_brokers.add(broker)
+        # Parker membership is only added via the Parker alias announce:
+        # a broker announcing on the legacy topic is not necessarily
+        # Parker-capable (e.g. during a staged rollout).
     else:
         if broker in active_brokers:
             logger.info(
                 f"Broker marked offline: {broker}, {len(active_brokers) - 1} brokers online"
             )
             active_brokers.discard(broker)
+        # The retained legacy status and its last will are the canonical
+        # liveness source, so an offline announcement also clears the
+        # broker's Parker alias membership.
         if config.get_config().parker.enabled:
             parker_active_brokers.discard(broker)
 

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -510,7 +510,17 @@ def handle_mqtt_message_metrics(
         logger.error("Ignored MQTT message with empty worker or metrics label")
         return
 
-    data = int(message.payload)
+    try:
+        data = int(message.payload)
+    except Exception:
+        logger.error(
+            "Invalid metrics payload for %s/%s/%s: %s",
+            worker,
+            domain,
+            metric,
+            message.payload,
+        )
+        return
 
     logger.info(f"Update worker metrics: {metric} on {worker}/{domain} = {data}")
     worker_metrics.update(worker, domain, metric, data)
@@ -530,7 +540,13 @@ def handle_mqtt_message_parker_metrics(
         logger.error("Ignored MQTT message with empty worker or metrics label")
         return
 
-    data = int(message.payload)
+    try:
+        data = int(message.payload)
+    except Exception:
+        logger.error(
+            "Invalid metrics payload for %s/%s: %s", worker, metric, message.payload
+        )
+        return
 
     logger.info(f"Update Parker worker metrics: {metric} on {worker} = {data}")
     parker_worker_metrics.update(worker, "parker", metric, data)
@@ -543,7 +559,13 @@ def handle_mqtt_message_status(
     """Processes status messages from workers."""
     _, worker, _ = message.topic.split("/", 2)
 
-    status = int(message.payload)
+    try:
+        status = int(message.payload)
+    except Exception:
+        logger.error(
+            "Invalid worker status payload for %s: %s", worker, message.payload
+        )
+        return
     if status < 1 and worker_metrics.get(worker).is_online():
         logger.warning(f"Marking worker as offline: {worker}")
         worker_metrics.set_offline(worker)
@@ -559,7 +581,13 @@ def handle_mqtt_message_parker_status(
     """Processes status messages from workers."""
     _, _, worker, _ = message.topic.split("/", 3)
 
-    status = int(message.payload)
+    try:
+        status = int(message.payload)
+    except Exception:
+        logger.error(
+            "Invalid worker status payload for %s: %s", worker, message.payload
+        )
+        return
     if status < 1 and parker_worker_metrics.get(worker).is_online():
         logger.warning(f"Marking Parker worker as offline: {worker}")
         parker_worker_metrics.set_offline(worker)

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -343,10 +343,14 @@ def wg_api_v3_key_exchange() -> Tuple[Response | Dict, int]:
         logger.error("No worker online for Parker network")
         if len(parker_worker_data) > 0:
             # Emergency mode - try to randomly select one for which we still have connection data cached
+            fallback_name = random.choice(list(parker_worker_data.keys()))
+            # Use the configured worker ID: the ID identifies the tunnel on the node,
+            # so it must not change depending on how the concentrator was selected
+            fallback_cfg = config.get_config().workers.get(fallback_name)
             selected_workers.append(
                 WorkerResult(
-                    name=random.choice(list(parker_worker_data.keys())),
-                    id=0,
+                    name=fallback_name,
+                    id=fallback_cfg.id if fallback_cfg else 0,
                     diff=0,
                     peers=0,
                     target=0,

--- a/wgkex/broker/app.py
+++ b/wgkex/broker/app.py
@@ -97,9 +97,8 @@ def _load_parker_ipam() -> Optional[ParkerIPAM]:
         case config.Parker.IPAM.NETBOX:
             netbox_cfg = config.get_config().netbox
             if netbox_cfg is None:
-                # This should not happen due to earlier config validation
-                raise Exception(
-                    "Missing config for NetBox IPAM. This is also a config parser bug, please report."
+                raise ValueError(
+                    "Parker is enabled with NetBox IPAM, but no netbox config is set in the config file"
                 )
 
             ipam = NetboxIPAM(

--- a/wgkex/broker/app_test.py
+++ b/wgkex/broker/app_test.py
@@ -201,6 +201,7 @@ class TestBrokerApp(unittest.TestCase):
             self.assertEqual(self.broker_app._load_parker_ipam(), "json-ipam")
 
         cfg.parker.ipam = config.Parker.IPAM.NETBOX
+        cfg.parker.xlat = False
         cfg.netbox = config.Netbox(url="https://netbox", api_key="token")
         with (
             mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
@@ -210,7 +211,7 @@ class TestBrokerApp(unittest.TestCase):
         ):
             self.assertEqual(self.broker_app._load_parker_ipam(), "netbox-ipam")
         netbox.assert_called_once_with(
-            api_url="https://netbox", token="token", xlat=True
+            api_url="https://netbox", token="token", xlat=False
         )
 
         cfg.netbox = None
@@ -235,7 +236,18 @@ class TestBrokerApp(unittest.TestCase):
                 client, b"", {}, paho.mqtt.enums.ConnackCode.CONNACK_ACCEPTED
             )
         self.assertEqual(mqtt.subscribe.call_count, 4)
-        mqtt.publish.assert_called_once_with(mock.ANY, 1, qos=1, retain=True)
+        legacy_topic = self.broker_app.MQTTTopics.TOPIC_BROKER_ANNOUNCE.format(
+            broker=self.broker_app._HOSTNAME
+        )
+        parker_topic = self.broker_app.MQTTTopics.TOPIC_PARKER_BROKER_ANNOUNCE.format(
+            broker=self.broker_app._HOSTNAME
+        )
+        mqtt.publish.assert_has_calls(
+            [
+                mock.call(legacy_topic, 1, qos=1, retain=True),
+                mock.call(parker_topic, b"", qos=1, retain=True),
+            ]
+        )
 
         mqtt.reset_mock()
         with mock.patch.object(self.broker_app, "mqtt", mqtt):
@@ -319,6 +331,20 @@ class TestBrokerApp(unittest.TestCase):
         self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
         self.assertNotIn("broker", self.broker_app.active_brokers)
 
+        parker_cfg = _parker_config()
+        with mock.patch.object(
+            self.broker_app.config, "get_config", return_value=parker_cfg
+        ):
+            message.payload = b"1"
+            self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
+            self.assertIn("broker", self.broker_app.active_brokers)
+            self.assertNotIn("broker", self.broker_app.parker_active_brokers)
+
+            self.broker_app.parker_active_brokers.add("broker")
+            message.payload = b"0"
+            self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
+            self.assertNotIn("broker", self.broker_app.parker_active_brokers)
+
         message.payload = b"1"
         self.broker_app.handle_mqtt_message_broker_status(None, b"", message)
         self.assertIn("broker", self.broker_app.active_brokers)
@@ -395,6 +421,7 @@ class TestBrokerApp(unittest.TestCase):
                 "/config", query_string=query
             )
             self.assertEqual(response.status_code, 400)
+            ipam.update_prefix.assert_not_called()
 
             self.broker_app.parker_worker_data["worker"] = {
                 "LinkAddress": "fe80::1",
@@ -402,15 +429,20 @@ class TestBrokerApp(unittest.TestCase):
                 "Port": 51820,
                 "PublicKey": "gateway-key",
             }
-            # An unconfigured worker must not be used as emergency fallback:
-            # its concentrator ID would not be unique or stable.
             response = self.broker_app.app.test_client().get(
                 "/config", query_string=query
             )
             self.assertEqual(response.status_code, 400)
+            ipam.update_prefix.assert_not_called()
 
-            # A configured worker is used as fallback with its configured ID.
             cfg.workers = config.Workers.from_dict({"worker": {"id": 7}}, 10)
+            response = self.broker_app.app.test_client().get(
+                "/config", query_string=query
+            )
+            self.assertEqual(response.status_code, 400)
+            ipam.update_prefix.assert_not_called()
+
+            self.broker_app.parker_worker_metrics.set_online("worker")
             with mock.patch.object(
                 self.broker_app, "sign_response", return_value=b"signature"
             ):
@@ -420,8 +452,12 @@ class TestBrokerApp(unittest.TestCase):
             self.assertEqual(response.status_code, 200)
             payload = json.loads(response.data.split(b"\n", 1)[0])
             self.assertEqual(payload["concentrators"][0]["id"], 7)
+            ipam.update_prefix.assert_called_once_with(
+                _PUBLIC_KEY, False, True, ["worker"]
+            )
 
             self.broker_app.parker_worker_data.clear()
+            ipam.update_prefix.reset_mock()
             with mock.patch.object(
                 self.broker_app.parker_worker_metrics,
                 "get_best_workers",
@@ -431,6 +467,7 @@ class TestBrokerApp(unittest.TestCase):
                     "/config", query_string=query
                 )
             self.assertEqual(response.status_code, 500)
+            ipam.update_prefix.assert_not_called()
 
             self.broker_app.parker_worker_data["worker"] = {
                 "LinkAddress": "fe80::1",

--- a/wgkex/broker/app_test.py
+++ b/wgkex/broker/app_test.py
@@ -216,7 +216,7 @@ class TestBrokerApp(unittest.TestCase):
         cfg.netbox = None
         with (
             mock.patch.object(self.broker_app.config, "get_config", return_value=cfg),
-            self.assertRaisesRegex(Exception, "Missing config for NetBox"),
+            self.assertRaisesRegex(ValueError, "no netbox config"),
         ):
             self.broker_app._load_parker_ipam()
 

--- a/wgkex/broker/app_test.py
+++ b/wgkex/broker/app_test.py
@@ -510,6 +510,31 @@ class TestBrokerApp(unittest.TestCase):
         )
         self.assertNotIn("broker", self.broker_app.parker_active_brokers)
 
+    def test_metric_and_status_handlers_ignore_invalid_payloads(self):
+        self.broker_app.handle_mqtt_message_metrics(
+            None,
+            b"",
+            _message(f"wireguard-metrics/{_DOMAIN}/worker/connected_peers", b""),
+        )
+        self.assertNotIn("worker", self.broker_app.worker_metrics.data)
+        self.broker_app.handle_mqtt_message_parker_metrics(
+            None,
+            b"",
+            _message("parker/wireguard-metrics/worker/connected_peers", b"invalid"),
+        )
+        self.assertNotIn("worker", self.broker_app.parker_worker_metrics.data)
+
+        with mock.patch.object(self.broker_app.worker_metrics, "get") as get:
+            self.broker_app.handle_mqtt_message_status(
+                None, b"", _message("wireguard-worker/worker/status", b"")
+            )
+        get.assert_not_called()
+        with mock.patch.object(self.broker_app.parker_worker_metrics, "get") as get:
+            self.broker_app.handle_mqtt_message_parker_status(
+                None, b"", _message("parker/wireguard-worker/worker/status", b"invalid")
+            )
+        get.assert_not_called()
+
     def test_shutdown_still_exits_when_publish_fails(self):
         with (
             mock.patch.object(

--- a/wgkex/broker/app_test.py
+++ b/wgkex/broker/app_test.py
@@ -402,6 +402,15 @@ class TestBrokerApp(unittest.TestCase):
                 "Port": 51820,
                 "PublicKey": "gateway-key",
             }
+            # An unconfigured worker must not be used as emergency fallback:
+            # its concentrator ID would not be unique or stable.
+            response = self.broker_app.app.test_client().get(
+                "/config", query_string=query
+            )
+            self.assertEqual(response.status_code, 400)
+
+            # A configured worker is used as fallback with its configured ID.
+            cfg.workers = config.Workers.from_dict({"worker": {"id": 7}}, 10)
             with mock.patch.object(
                 self.broker_app, "sign_response", return_value=b"signature"
             ):
@@ -410,7 +419,7 @@ class TestBrokerApp(unittest.TestCase):
                 )
             self.assertEqual(response.status_code, 200)
             payload = json.loads(response.data.split(b"\n", 1)[0])
-            self.assertEqual(payload["concentrators"][0]["id"], 0)
+            self.assertEqual(payload["concentrators"][0]["id"], 7)
 
             self.broker_app.parker_worker_data.clear()
             with mock.patch.object(

--- a/wgkex/broker/ipam_json.py
+++ b/wgkex/broker/ipam_json.py
@@ -87,9 +87,6 @@ class JSONFileIPAM(ParkerIPAM):
                     prefixes = parent_prefix.subnets(new_prefix=ipv6_prefix_length)
                     next(prefixes)  # Reserve the first prefix for infrastructure.
                     for candidate in prefixes:
-                        # Check for overlap instead of equality: stored ranges
-                        # may have a different length than the currently
-                        # configured one (e.g. after a config change).
                         if not any(
                             candidate.overlaps(stored) for stored in parsed_ranges
                         ):

--- a/wgkex/broker/ipam_json.py
+++ b/wgkex/broker/ipam_json.py
@@ -87,7 +87,12 @@ class JSONFileIPAM(ParkerIPAM):
                     prefixes = parent_prefix.subnets(new_prefix=ipv6_prefix_length)
                     next(prefixes)  # Reserve the first prefix for infrastructure.
                     for candidate in prefixes:
-                        if candidate not in parsed_ranges:
+                        # Check for overlap instead of equality: stored ranges
+                        # may have a different length than the currently
+                        # configured one (e.g. after a config change).
+                        if not any(
+                            candidate.overlaps(stored) for stored in parsed_ranges
+                        ):
                             range6 = str(candidate)
                             break
                     if range6 is None:

--- a/wgkex/broker/ipam_json_test.py
+++ b/wgkex/broker/ipam_json_test.py
@@ -1,3 +1,4 @@
+import ipaddress
 import json
 import multiprocessing
 import os
@@ -48,6 +49,29 @@ class TestJSONFileIPAM(unittest.TestCase):
                     "pubkey-a": str(first_prefix),
                     "pubkey-b": str(second_prefix),
                 },
+            )
+
+    def test_allocation_avoids_overlap_with_differently_sized_ranges(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            with open(storage_path, "w", encoding="utf-8") as ranges_file:
+                json.dump(
+                    {
+                        "parent_prefix": "2001:db8:ed0::/56",
+                        # Stored with a different length than the requested
+                        # /63, e.g. after a config change.
+                        "ranges": {"pubkey-a": "2001:db8:ed0:2::/64"},
+                    },
+                    ranges_file,
+                )
+
+            _, new_prefix, _ = JSONFileIPAM(storage_path).get_or_allocate_prefix(
+                "pubkey-b", ipv4=False, ipv6=True, ipv6_prefix_length=63
+            )
+
+            self.assertIsNotNone(new_prefix)
+            self.assertFalse(
+                new_prefix.overlaps(ipaddress.IPv6Network("2001:db8:ed0:2::/64"))
             )
 
     def test_invalid_json_is_reported_without_overwriting_storage(self):

--- a/wgkex/broker/ipam_json_test.py
+++ b/wgkex/broker/ipam_json_test.py
@@ -51,29 +51,6 @@ class TestJSONFileIPAM(unittest.TestCase):
                 },
             )
 
-    def test_allocation_avoids_overlap_with_differently_sized_ranges(self):
-        with tempfile.TemporaryDirectory() as temporary_dir:
-            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
-            with open(storage_path, "w", encoding="utf-8") as ranges_file:
-                json.dump(
-                    {
-                        "parent_prefix": "2001:db8:ed0::/56",
-                        # Stored with a different length than the requested
-                        # /63, e.g. after a config change.
-                        "ranges": {"pubkey-a": "2001:db8:ed0:2::/64"},
-                    },
-                    ranges_file,
-                )
-
-            _, new_prefix, _ = JSONFileIPAM(storage_path).get_or_allocate_prefix(
-                "pubkey-b", ipv4=False, ipv6=True, ipv6_prefix_length=63
-            )
-
-            self.assertIsNotNone(new_prefix)
-            self.assertFalse(
-                new_prefix.overlaps(ipaddress.IPv6Network("2001:db8:ed0:2::/64"))
-            )
-
     def test_invalid_json_is_reported_without_overwriting_storage(self):
         with tempfile.TemporaryDirectory() as temporary_dir:
             storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
@@ -87,6 +64,27 @@ class TestJSONFileIPAM(unittest.TestCase):
 
             with open(storage_path, "r", encoding="utf-8") as ranges_file:
                 self.assertEqual(ranges_file.read(), "{invalid")
+
+    def test_allocation_avoids_overlap_with_differently_sized_ranges(self):
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            storage_path = os.path.join(temporary_dir, "ipv6_ranges.json")
+            with open(storage_path, "w", encoding="utf-8") as ranges_file:
+                json.dump(
+                    {
+                        "parent_prefix": "2001:db8:ed0::/56",
+                        "ranges": {"pubkey-a": "2001:db8:ed0:2::/64"},
+                    },
+                    ranges_file,
+                )
+
+            _, new_prefix, _ = JSONFileIPAM(storage_path).get_or_allocate_prefix(
+                "pubkey-b", ipv4=False, ipv6=True, ipv6_prefix_length=63
+            )
+
+            self.assertIsNotNone(new_prefix)
+            self.assertFalse(
+                new_prefix.overlaps(ipaddress.IPv6Network("2001:db8:ed0:2::/64"))
+            )
 
     def test_exhausted_parent_prefix_returns_no_allocation(self):
         with tempfile.TemporaryDirectory() as temporary_dir:

--- a/wgkex/broker/ipam_netbox.py
+++ b/wgkex/broker/ipam_netbox.py
@@ -59,7 +59,9 @@ class NetboxIPAM(ParkerIPAM):
             if self.parent_prefix_v4 is None:
                 raise ValueError("No parent IPv4 prefix loaded (464XLAT mode enabled?)")
             return self.parent_prefix_v4
-        return self.parent_prefix_v6
+        if addr_family == 6:
+            return self.parent_prefix_v6
+        raise ValueError(f"Unsupported address family: {addr_family}")
 
     def _get_prefixes(
         self,

--- a/wgkex/broker/ipam_netbox.py
+++ b/wgkex/broker/ipam_netbox.py
@@ -22,6 +22,7 @@ class NetboxIPAM(ParkerIPAM):
     def __init__(self, api_url, token, xlat: bool = False) -> None:
         self.nb = pynetbox.api(api_url, token=token)
         self.xlat = xlat
+        self.parent_prefix_v4 = None
 
         v6_filter: dict[str, Any] = (
             config.get_config().parker.prefixes.ipv6.netbox_filter or {}
@@ -52,6 +53,14 @@ class NetboxIPAM(ParkerIPAM):
 
             self.parent_prefix_v4 = next(prefixes_v4)
 
+    def _parent_prefix(self, addr_family: int) -> pynetbox.models.ipam.Prefixes:
+        """Returns the parent prefix for the given address family."""
+        if addr_family == 4:
+            if self.parent_prefix_v4 is None:
+                raise ValueError("No parent IPv4 prefix loaded (464XLAT mode enabled?)")
+            return self.parent_prefix_v4
+        return self.parent_prefix_v6
+
     def _get_prefixes(
         self,
         pubkey: str,
@@ -60,7 +69,7 @@ class NetboxIPAM(ParkerIPAM):
         # https://netboxlabs.com/docs/netbox/reference/filtering/#string-fields
         candidate_prefixes = self.nb.ipam.prefixes.filter(
             family=addr_family,
-            within=self.parent_prefix_v6.prefix,
+            within=self._parent_prefix(addr_family).prefix,
             description__ic=pubkey,  # __ic: Contains (case-insensitive)
         )
 
@@ -166,7 +175,7 @@ class NetboxIPAM(ParkerIPAM):
             # Allocates a new free prefix in a concurrency-safe manner (handled by NetBox)
             # TODO: allow specifying a custom field to write this data into instead
             try:
-                res = self.parent_prefix_v6.available_prefixes.create(
+                res = self._parent_prefix(addr_family).available_prefixes.create(
                     {
                         "prefix_length": prefix_length,
                         "description": description,

--- a/wgkex/broker/ipam_netbox_test.py
+++ b/wgkex/broker/ipam_netbox_test.py
@@ -450,6 +450,52 @@ class TestNetboxIPAM(unittest.TestCase):
         _, _, workers = ipam.get_or_allocate_prefix("pubkey", ipv4=True, ipv6=True)
         self.assertEqual(workers, ["worker-v4"])
 
+    def test_ipv4_lookups_and_allocations_use_ipv4_parent(self):
+        ipam = object.__new__(NetboxIPAM)
+        ipam.nb = mock.MagicMock()
+        ipam.parent_prefix_v4 = mock.MagicMock(prefix="10.0.0.0/8")
+        ipam.parent_prefix_v6 = mock.MagicMock(prefix="2001:db8::/32")
+        ipam.nb.ipam.prefixes.filter.return_value = []
+
+        self.assertEqual(ipam._get_prefixes("pubkey", 4), [])
+        ipam.nb.ipam.prefixes.filter.assert_called_once_with(
+            family=4,
+            within="10.0.0.0/8",
+            description__ic="pubkey",
+        )
+
+        class FakePrefix:
+            id = 1
+            prefix = "10.0.0.0/24"
+            description = '{"pubkey":"pubkey"}'
+
+        allocated = FakePrefix()
+        ipam.parent_prefix_v4.available_prefixes.create.return_value = allocated
+        with (
+            mock.patch.object(
+                ipam, "_deduplicate_prefixes", side_effect=[None, allocated]
+            ),
+            mock.patch(
+                "wgkex.broker.ipam_netbox.pynetbox.models.ipam.Prefixes",
+                FakePrefix,
+            ),
+        ):
+            prefix, _ = ipam._get_or_allocate_prefix("pubkey", 4, 24, None)
+
+        self.assertIs(prefix, allocated)
+        ipam.parent_prefix_v4.available_prefixes.create.assert_called_once()
+        ipam.parent_prefix_v6.available_prefixes.create.assert_not_called()
+
+    def test_parent_prefix_rejects_unavailable_or_invalid_family(self):
+        ipam = object.__new__(NetboxIPAM)
+        ipam.parent_prefix_v4 = None
+        ipam.parent_prefix_v6 = mock.MagicMock()
+
+        with self.assertRaisesRegex(ValueError, "No parent IPv4"):
+            ipam._parent_prefix(4)
+        with self.assertRaisesRegex(ValueError, "Unsupported address family"):
+            ipam._parent_prefix(5)
+
     def test_update_prefix_handles_save_failure_and_both_families(self):
         prefix = mock.MagicMock(
             prefix="2001:db8::/63",

--- a/wgkex/broker/metrics.py
+++ b/wgkex/broker/metrics.py
@@ -121,9 +121,18 @@ class WorkerMetricsCollection:
         return (worker.name, worker.diff, worker.peers)
 
     def get_best_workers(
-        self, domain: str, current_selected_workers: Optional[List[str]]
+        self,
+        domain: str,
+        current_selected_workers: Optional[List[str]],
+        require_configured: bool = False,
     ) -> List[WorkerResult]:
         """Analyzes the metrics and determines the best worker for each PoP that a node should connect to.
+
+        With require_configured, workers that are missing from the workers
+        config are skipped instead of getting a synthetic default config.
+        Parker mode requires this: the worker's id is the concentrator ID
+        identifying the tunnel on the node, so it must be unique and stable,
+        which a synthetic default (id=0 for every unconfigured worker) is not.
 
         If no current_selected_workers is passed (None or empty):
             The best worker is defined as the one with the most number of clients missing
@@ -151,9 +160,14 @@ class WorkerMetricsCollection:
 
             # Map metrics to a list of (target diff, peer count, worker) tuples for online workers
             for wm in self.data.values():
-                worker_cfg = workers_cfg.get(wm.worker) or config.Worker(
-                    id=0, weight=1, pop=""
-                )
+                worker_cfg = workers_cfg.get(wm.worker)
+                if worker_cfg is None:
+                    if require_configured:
+                        logger.warning(
+                            f"Worker {wm.worker} is not in the workers config, skipping"
+                        )
+                        continue
+                    worker_cfg = config.Worker(id=0, weight=1, pop="")
 
                 if worker_cfg.pop != pop:
                     continue

--- a/wgkex/broker/metrics.py
+++ b/wgkex/broker/metrics.py
@@ -128,12 +128,6 @@ class WorkerMetricsCollection:
     ) -> List[WorkerResult]:
         """Analyzes the metrics and determines the best worker for each PoP that a node should connect to.
 
-        With require_configured, workers that are missing from the workers
-        config are skipped instead of getting a synthetic default config.
-        Parker mode requires this: the worker's id is the concentrator ID
-        identifying the tunnel on the node, so it must be unique and stable,
-        which a synthetic default (id=0 for every unconfigured worker) is not.
-
         If no current_selected_workers is passed (None or empty):
             The best worker is defined as the one with the most number of clients missing
             to its should-be target value according to its weight.
@@ -164,7 +158,8 @@ class WorkerMetricsCollection:
                 if worker_cfg is None:
                     if require_configured:
                         logger.warning(
-                            f"Worker {wm.worker} is not in the workers config, skipping"
+                            "Worker %s is not in the workers config, skipping",
+                            wm.worker,
                         )
                         continue
                     worker_cfg = config.Worker(id=0, weight=1, pop="")
@@ -195,9 +190,6 @@ class WorkerMetricsCollection:
                     if len(all_matched) > 0:
                         matched = all_matched[0]
 
-                        # Allow at least one peer of slack: with small targets
-                        # a relative tolerance alone evicts on any overshoot,
-                        # making nodes ping-pong between workers.
                         if matched.diff > max(
                             1, workers_cfg.sticky_worker_tolerance * matched.target
                         ):

--- a/wgkex/broker/metrics.py
+++ b/wgkex/broker/metrics.py
@@ -195,10 +195,11 @@ class WorkerMetricsCollection:
                     if len(all_matched) > 0:
                         matched = all_matched[0]
 
-                        if (
-                            matched.diff > 0
-                            and matched.diff
-                            > workers_cfg.sticky_worker_tolerance * matched.target
+                        # Allow at least one peer of slack: with small targets
+                        # a relative tolerance alone evicts on any overshoot,
+                        # making nodes ping-pong between workers.
+                        if matched.diff > max(
+                            1, workers_cfg.sticky_worker_tolerance * matched.target
                         ):
                             continue
 

--- a/wgkex/broker/metrics.py
+++ b/wgkex/broker/metrics.py
@@ -155,8 +155,6 @@ class WorkerMetricsCollection:
                     id=0, weight=1, pop=""
                 )
 
-                print(worker_cfg)
-
                 if worker_cfg.pop != pop:
                     continue
 

--- a/wgkex/broker/metrics_test.py
+++ b/wgkex/broker/metrics_test.py
@@ -85,10 +85,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(connected, 19)
 
     @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
-    def test_get_best_workers_require_configured_skips_unknown_workers(
-        self, config_mock
-    ):
-        """Verify require_configured only selects workers with a config entry."""
+    def test_parker_selection_skips_unconfigured_workers(self, config_mock):
         test_config = mock.MagicMock(spec=config.Config)
         test_config.workers = config.Workers.from_dict({"1": {"id": 5}}, 25)
         config_mock.return_value = test_config
@@ -100,12 +97,11 @@ class TestMetrics(unittest.TestCase):
         worker_metrics.set_online("2")
 
         results = worker_metrics.get_best_workers("d", [], require_configured=True)
-        self.assertEqual([r.name for r in results], ["1"])
+        self.assertEqual([result.name for result in results], ["1"])
         self.assertEqual(results[0].id, 5)
 
-        # Without the flag, unconfigured workers stay selectable (legacy mode).
         results = worker_metrics.get_best_workers("d", [])
-        self.assertIn("2", [r.name for r in results])
+        self.assertIn("2", [result.name for result in results])
 
     @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
     def test_get_best_worker_returns_best_imbalanced_domains(self, config_mock):
@@ -191,30 +187,6 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(results[0].name, "2")
 
     @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
-    def test_get_best_worker_stickyness_small_target(self, config_mock):
-        """Verify a sticky worker one peer over a small target is kept.
-
-        With small targets the relative tolerance alone is below one peer, so
-        any overshoot would evict the sticky worker and make nodes ping-pong
-        between workers."""
-        test_config = mock.MagicMock(spec=config.Config)
-        test_config.workers = config.Workers.from_dict(
-            {"1": {"id": 1, "weight": 50}, "2": {"id": 2, "weight": 50}}, 10
-        )
-        config_mock.return_value = test_config
-
-        worker_metrics = WorkerMetricsCollection()
-        # Total 4 peers, target 2 per worker; tolerance 10% of 2 = 0.2 peers.
-        worker_metrics.update("1", "d", "connected_peers", 1)
-        worker_metrics.update("2", "d", "connected_peers", 3)
-        worker_metrics.set_online("1")
-        worker_metrics.set_online("2")
-
-        results = worker_metrics.get_best_workers("d", current_selected_workers=["2"])
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].name, "2")
-
-    @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
     def test_overloaded_sticky_worker_is_replaced(self, config_mock):
         test_config = mock.MagicMock(spec=config.Config)
         test_config.workers = config.Workers.from_dict(
@@ -243,6 +215,23 @@ class TestMetrics(unittest.TestCase):
         self.assertCountEqual(
             [result.name for result in results], ["available", "other-pop"]
         )
+
+    @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
+    def test_small_target_keeps_sticky_worker_with_one_peer_slack(self, config_mock):
+        test_config = mock.MagicMock(spec=config.Config)
+        test_config.workers = config.Workers.from_dict(
+            {"1": {"id": 1, "weight": 50}, "2": {"id": 2, "weight": 50}}, 10
+        )
+        config_mock.return_value = test_config
+
+        worker_metrics = WorkerMetricsCollection()
+        worker_metrics.update("1", "d", "connected_peers", 1)
+        worker_metrics.update("2", "d", "connected_peers", 3)
+        worker_metrics.set_online("1")
+        worker_metrics.set_online("2")
+
+        results = worker_metrics.get_best_workers("d", current_selected_workers=["2"])
+        self.assertEqual([result.name for result in results], ["2"])
 
     def test_collection_set_and_total_skip_missing_record(self):
         worker_metrics = WorkerMetricsCollection()

--- a/wgkex/broker/metrics_test.py
+++ b/wgkex/broker/metrics_test.py
@@ -191,6 +191,30 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(results[0].name, "2")
 
     @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
+    def test_get_best_worker_stickyness_small_target(self, config_mock):
+        """Verify a sticky worker one peer over a small target is kept.
+
+        With small targets the relative tolerance alone is below one peer, so
+        any overshoot would evict the sticky worker and make nodes ping-pong
+        between workers."""
+        test_config = mock.MagicMock(spec=config.Config)
+        test_config.workers = config.Workers.from_dict(
+            {"1": {"id": 1, "weight": 50}, "2": {"id": 2, "weight": 50}}, 10
+        )
+        config_mock.return_value = test_config
+
+        worker_metrics = WorkerMetricsCollection()
+        # Total 4 peers, target 2 per worker; tolerance 10% of 2 = 0.2 peers.
+        worker_metrics.update("1", "d", "connected_peers", 1)
+        worker_metrics.update("2", "d", "connected_peers", 3)
+        worker_metrics.set_online("1")
+        worker_metrics.set_online("2")
+
+        results = worker_metrics.get_best_workers("d", current_selected_workers=["2"])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].name, "2")
+
+    @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
     def test_overloaded_sticky_worker_is_replaced(self, config_mock):
         test_config = mock.MagicMock(spec=config.Config)
         test_config.workers = config.Workers.from_dict(

--- a/wgkex/broker/metrics_test.py
+++ b/wgkex/broker/metrics_test.py
@@ -85,6 +85,29 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(connected, 19)
 
     @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
+    def test_get_best_workers_require_configured_skips_unknown_workers(
+        self, config_mock
+    ):
+        """Verify require_configured only selects workers with a config entry."""
+        test_config = mock.MagicMock(spec=config.Config)
+        test_config.workers = config.Workers.from_dict({"1": {"id": 5}}, 25)
+        config_mock.return_value = test_config
+
+        worker_metrics = WorkerMetricsCollection()
+        worker_metrics.update("1", "d", "connected_peers", 20)
+        worker_metrics.update("2", "d", "connected_peers", 0)
+        worker_metrics.set_online("1")
+        worker_metrics.set_online("2")
+
+        results = worker_metrics.get_best_workers("d", [], require_configured=True)
+        self.assertEqual([r.name for r in results], ["1"])
+        self.assertEqual(results[0].id, 5)
+
+        # Without the flag, unconfigured workers stay selectable (legacy mode).
+        results = worker_metrics.get_best_workers("d", [])
+        self.assertIn("2", [r.name for r in results])
+
+    @mock.patch("wgkex.broker.metrics.config.get_config", autospec=True)
     def test_get_best_worker_returns_best_imbalanced_domains(self, config_mock):
         """Verify get_best_worker returns the worker with overall least connected clients even if it has more clients on this domain."""
         test_config = mock.MagicMock(spec=config.Config)

--- a/wgkex/broker/parker.py
+++ b/wgkex/broker/parker.py
@@ -20,10 +20,8 @@ class ParkerQuery:
     pubkey: str
     nonce: str
 
-    def __init__(self, v6mtu: int, pubkey: str, nonce: str) -> None:
-        self.v6mtu = v6mtu
-        self.pubkey = is_valid_wg_pubkey(pubkey)
-        self.nonce = nonce
+    def __post_init__(self) -> None:
+        self.pubkey = is_valid_wg_pubkey(self.pubkey)
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "ParkerQuery":

--- a/wgkex/broker/parker_test.py
+++ b/wgkex/broker/parker_test.py
@@ -66,6 +66,18 @@ class TestParkerQuery(unittest.TestCase):
         with self.assertRaises(ValueError):
             ParkerQuery.from_dict(data)
 
+    def test_parker_query_generated_init_validates_direct_construction(self):
+        from wgkex.broker.parker import ParkerQuery
+
+        query = ParkerQuery(
+            v6mtu=1280,
+            pubkey="TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=",
+            nonce="nonce",
+        )
+        self.assertEqual(query.v6mtu, 1280)
+        with self.assertRaises(ValueError):
+            ParkerQuery(v6mtu=1280, pubkey="invalid", nonce="nonce")
+
     def test_parker_response_requires_clat_subnet_at_construction(self):
         from wgkex.broker.parker import ParkerResponse
 
@@ -145,19 +157,12 @@ class TestParker(unittest.TestCase):
 
         flask_mqtt_stub.Mqtt = MqttStub
         sys.modules["flask_mqtt"] = flask_mqtt_stub
-
-        # Import broker.app freshly under this class's config and stubs. A plain
-        # `from wgkex.broker import app` would return a stale module left on the
-        # package attribute by an earlier test module (e.g. app_test), which was
-        # imported with Parker disabled.
         sys.modules.pop("wgkex.broker.app", None)
         importlib.import_module("wgkex.broker.app")
 
     @classmethod
     def tearDownClass(cls) -> None:
         config._parsed_config = None
-        # Restore the stubbed modules and drop broker.app (imported with the
-        # stubs baked in), so later test modules import the real thing
         for name, module in cls._original_modules.items():
             if module is None:
                 sys.modules.pop(name, None)
@@ -243,6 +248,35 @@ class TestParker(unittest.TestCase):
 
         self.assertEqual(response.status_code, 500)
 
+    def test_config_route_warns_for_safe_prefix_length_mismatch(self):
+        from wgkex.broker import app as broker_app
+
+        ipam = mock.MagicMock()
+        ipam.get_or_allocate_prefix.return_value = (
+            None,
+            ipaddress.IPv6Network("2001:db8:42::/62"),
+            [],
+        )
+        query = {
+            "pubkey": "TszFS3oFRdhsJP3K0VOlklGMGYZy+oFCtlaghXJqW2g=",
+            "nonce": "nonce",
+        }
+        with (
+            mock.patch.object(broker_app, "ipam", ipam),
+            mock.patch.object(broker_app.logger, "warning") as warning,
+        ):
+            response = broker_app.app.test_client().get("/config", query_string=query)
+
+        self.assertEqual(response.status_code, 400)
+        warning.assert_any_call(
+            "IPv6 prefix %s for public key %s has length /%s, but /%s is configured. "
+            "Fix or delete the prefix in the IPAM.",
+            ipaddress.IPv6Network("2001:db8:42::/62"),
+            query["pubkey"],
+            62,
+            63,
+        )
+
     def test_parker_mqtt_connect_keeps_legacy_discovery(self):
         from wgkex.broker import app as broker_app
         from wgkex.common.mqtt import MQTTTopics
@@ -280,8 +314,7 @@ class TestParker(unittest.TestCase):
         mqtt.publish.assert_has_calls(
             [
                 mock.call(legacy_topic, 1, qos=1, retain=True),
-                mock.call(parker_topic, b"", qos=1, retain=True),
-                mock.call(parker_topic, 1, qos=1, retain=False),
+                mock.call(parker_topic, 1, qos=1, retain=True),
             ]
         )
         self.assertEqual(broker_app.app.config["MQTT_LAST_WILL_TOPIC"], legacy_topic)
@@ -323,11 +356,7 @@ class TestParker(unittest.TestCase):
         msg.payload = b"1"
         broker_app.handle_mqtt_message_broker_status(None, None, msg)
         self.assertIn("broker1", broker_app.active_brokers)
-        # A legacy announce must not count the broker as Parker-capable.
         self.assertNotIn("broker1", broker_app.parker_active_brokers)
-
-        # An offline legacy announce (the canonical liveness source) clears
-        # the Parker alias membership too.
         broker_app.parker_active_brokers.add("broker1")
         msg.payload = b"0"
         broker_app.handle_mqtt_message_broker_status(None, None, msg)
@@ -374,6 +403,10 @@ class TestParker(unittest.TestCase):
         self.assertEqual(broker_app.get_active_brokers_count(parker=False), 1)
         broker_app.active_brokers.add("b")
         self.assertEqual(broker_app.get_active_brokers_count(parker=False), 2)
+        broker_app.parker_active_brokers.update(("a", "not-active"))
+        self.assertEqual(broker_app.get_active_brokers_count(parker=True), 1)
+        broker_app.parker_active_brokers.add("b")
+        self.assertEqual(broker_app.get_active_brokers_count(parker=True), 2)
 
     def test_ipam_loaded(self):
         from wgkex.broker import app as broker_app

--- a/wgkex/broker/parker_test.py
+++ b/wgkex/broker/parker_test.py
@@ -323,7 +323,12 @@ class TestParker(unittest.TestCase):
         msg.payload = b"1"
         broker_app.handle_mqtt_message_broker_status(None, None, msg)
         self.assertIn("broker1", broker_app.active_brokers)
-        self.assertIn("broker1", broker_app.parker_active_brokers)
+        # A legacy announce must not count the broker as Parker-capable.
+        self.assertNotIn("broker1", broker_app.parker_active_brokers)
+
+        # An offline legacy announce (the canonical liveness source) clears
+        # the Parker alias membership too.
+        broker_app.parker_active_brokers.add("broker1")
         msg.payload = b"0"
         broker_app.handle_mqtt_message_broker_status(None, None, msg)
         self.assertNotIn("broker1", broker_app.active_brokers)

--- a/wgkex/broker/parker_test.py
+++ b/wgkex/broker/parker_test.py
@@ -1,3 +1,4 @@
+import importlib
 import ipaddress
 import json
 import mock
@@ -99,6 +100,10 @@ class TestParker(unittest.TestCase):
         config._parsed_config = test_config
 
         # Stub out signer module before importing broker.app which imports it at module level
+        cls._original_modules = {
+            name: sys.modules.get(name)
+            for name in ("wgkex.broker.signer", "flask_mqtt")
+        }
         sys.modules["wgkex.broker.signer"] = mock.MagicMock()
 
         # Stub out flask_mqtt.Mqtt to avoid network connections during import
@@ -141,9 +146,24 @@ class TestParker(unittest.TestCase):
         flask_mqtt_stub.Mqtt = MqttStub
         sys.modules["flask_mqtt"] = flask_mqtt_stub
 
+        # Import broker.app freshly under this class's config and stubs. A plain
+        # `from wgkex.broker import app` would return a stale module left on the
+        # package attribute by an earlier test module (e.g. app_test), which was
+        # imported with Parker disabled.
+        sys.modules.pop("wgkex.broker.app", None)
+        importlib.import_module("wgkex.broker.app")
+
     @classmethod
     def tearDownClass(cls) -> None:
         config._parsed_config = None
+        # Restore the stubbed modules and drop broker.app (imported with the
+        # stubs baked in), so later test modules import the real thing
+        for name, module in cls._original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        sys.modules.pop("wgkex.broker.app", None)
 
     def test_join_host_port(self):
         from wgkex.broker import app as broker_app

--- a/wgkex/broker/signer.py
+++ b/wgkex/broker/signer.py
@@ -72,8 +72,22 @@ def get_private_key() -> Tuple[KeyType, ecdsa.SigningKey, Optional[bytes]]:
     fingerprint_bytes: Optional[bytes] = None
     if len(privkey_bytes) == 104:
         # signify-style format
+        kdfrounds = int.from_bytes(privkey_bytes[4:8], "big")
+        if kdfrounds != 0:
+            raise ValueError(
+                "The configured signify signing key is passphrase-protected "
+                "(kdfrounds > 0), which is not supported. Generate the key "
+                "without a passphrase using 'signify -G -n'."
+            )
+        checksum = privkey_bytes[24:32]
+        seckey = privkey_bytes[-64:]
+        if hashlib.sha512(seckey).digest()[:8] != checksum:
+            raise ValueError(
+                "The configured signify signing key has an invalid checksum. "
+                "The key is corrupt or truncated."
+            )
         fingerprint_bytes = privkey_bytes[32:40]
-        privkey_bytes = privkey_bytes[-64:-32]
+        privkey_bytes = seckey[:32]
         keytype = KeyType.SIGNIFY
     elif len(privkey_bytes) == 32:
         # raw format

--- a/wgkex/broker/signer.py
+++ b/wgkex/broker/signer.py
@@ -59,7 +59,10 @@ def get_private_key() -> Tuple[KeyType, ecdsa.SigningKey, Optional[bytes]]:
         raise ValueError("Response signing is not available in non-parker mode.")
 
     privkey_encoded = config.get_config().broker_signing_key
-    assert privkey_encoded is not None, "Private key must be set in the configuration."
+    if privkey_encoded is None:
+        raise ValueError(
+            "Parker is enabled, but no broker_signing_key is set in the config file"
+        )
 
     try:
         # ecdsautil-style format

--- a/wgkex/broker/signer_test.py
+++ b/wgkex/broker/signer_test.py
@@ -100,6 +100,15 @@ class TestSigner(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "checksum"):
             self.signer.get_private_key()
 
+    def test_missing_signing_key_raises_clear_error(self):
+        previous_config = config._parsed_config
+        self.addCleanup(setattr, config, "_parsed_config", previous_config)
+        config._parsed_config = _parker_config(None)
+        self.signer.get_private_key.cache_clear()
+
+        with self.assertRaisesRegex(ValueError, "broker_signing_key"):
+            self.signer.get_private_key()
+
     def test_signing_is_unavailable_when_parker_is_disabled(self):
         config._parsed_config = config.Config.from_dict(
             {

--- a/wgkex/broker/signer_test.py
+++ b/wgkex/broker/signer_test.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 import importlib
 import sys
 import unittest
@@ -50,11 +51,21 @@ class TestSigner(unittest.TestCase):
         self.assertEqual(len(signature), 64)
         self.assertTrue(private_key.verifying_key.verify(signature, data))
 
-    def test_signify_key_preserves_fingerprint_in_signature(self):
+    @staticmethod
+    def _signify_key(kdfrounds: int = 0, valid_checksum: bool = True) -> bytearray:
         serialized_key = bytearray(104)
-        fingerprint = b"12345678"
-        serialized_key[32:40] = fingerprint
+        serialized_key[0:2] = b"Ed"
+        serialized_key[2:4] = b"BK"
+        serialized_key[4:8] = kdfrounds.to_bytes(4, "big")
+        serialized_key[32:40] = b"12345678"
         serialized_key[40:72] = bytes(range(32))
+        if valid_checksum:
+            serialized_key[24:32] = hashlib.sha512(serialized_key[40:104]).digest()[:8]
+        return serialized_key
+
+    def test_signify_key_preserves_fingerprint_in_signature(self):
+        serialized_key = self._signify_key()
+        fingerprint = bytes(serialized_key[32:40])
         config._parsed_config = _parker_config(
             base64.b64encode(serialized_key).decode()
         )
@@ -68,6 +79,26 @@ class TestSigner(unittest.TestCase):
         signature = base64.b64decode(self.signer.sign_response(data))
         self.assertEqual(signature[:10], b"Ed" + fingerprint)
         self.assertTrue(private_key.verifying_key.verify(signature[10:], data))
+
+    def test_signify_key_rejects_passphrase_protected_key(self):
+        serialized_key = self._signify_key(kdfrounds=42)
+        config._parsed_config = _parker_config(
+            base64.b64encode(serialized_key).decode()
+        )
+        self.signer.get_private_key.cache_clear()
+
+        with self.assertRaisesRegex(ValueError, "passphrase-protected"):
+            self.signer.get_private_key()
+
+    def test_signify_key_rejects_invalid_checksum(self):
+        serialized_key = self._signify_key(valid_checksum=False)
+        config._parsed_config = _parker_config(
+            base64.b64encode(serialized_key).decode()
+        )
+        self.signer.get_private_key.cache_clear()
+
+        with self.assertRaisesRegex(ValueError, "checksum"):
+            self.signer.get_private_key()
 
     def test_signing_is_unavailable_when_parker_is_disabled(self):
         config._parsed_config = config.Config.from_dict(

--- a/wgkex/broker/signer_test.py
+++ b/wgkex/broker/signer_test.py
@@ -3,11 +3,12 @@ import hashlib
 import importlib
 import sys
 import unittest
+from typing import Optional
 
 from wgkex.config import config
 
 
-def _parker_config(signing_key: str) -> config.Config:
+def _parker_config(signing_key: Optional[str]) -> config.Config:
     return config.Config.from_dict(
         {
             "parker": {
@@ -37,6 +38,10 @@ class TestSigner(unittest.TestCase):
     def tearDownClass(cls) -> None:
         config._parsed_config = None
         sys.modules.pop("wgkex.broker.signer", None)
+
+    def setUp(self) -> None:
+        config._parsed_config = _parker_config(bytes(range(32)).hex())
+        self.signer.get_private_key.cache_clear()
 
     def tearDown(self) -> None:
         self.signer.get_private_key.cache_clear()
@@ -81,9 +86,8 @@ class TestSigner(unittest.TestCase):
         self.assertTrue(private_key.verifying_key.verify(signature[10:], data))
 
     def test_signify_key_rejects_passphrase_protected_key(self):
-        serialized_key = self._signify_key(kdfrounds=42)
         config._parsed_config = _parker_config(
-            base64.b64encode(serialized_key).decode()
+            base64.b64encode(self._signify_key(kdfrounds=42)).decode()
         )
         self.signer.get_private_key.cache_clear()
 
@@ -91,9 +95,8 @@ class TestSigner(unittest.TestCase):
             self.signer.get_private_key()
 
     def test_signify_key_rejects_invalid_checksum(self):
-        serialized_key = self._signify_key(valid_checksum=False)
         config._parsed_config = _parker_config(
-            base64.b64encode(serialized_key).decode()
+            base64.b64encode(self._signify_key(valid_checksum=False)).decode()
         )
         self.signer.get_private_key.cache_clear()
 
@@ -101,8 +104,6 @@ class TestSigner(unittest.TestCase):
             self.signer.get_private_key()
 
     def test_missing_signing_key_raises_clear_error(self):
-        previous_config = config._parsed_config
-        self.addCleanup(setattr, config, "_parsed_config", previous_config)
         config._parsed_config = _parker_config(None)
         self.signer.get_private_key.cache_clear()
 

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -42,9 +42,11 @@ class Worker:
 
     @classmethod
     def from_dict(cls, worker_cfg: Dict[str, Any]) -> "Worker":
+        # An explicit but empty key (e.g. "weight:") parses to None in YAML
+        # and must fall back to the default like a missing key.
         return cls(
-            weight=int(worker_cfg.get("weight", 1)),
-            pop=worker_cfg.get("pop", ""),
+            weight=int(worker_cfg.get("weight") or 1),
+            pop=worker_cfg.get("pop") or "",
             id=int(worker_cfg["id"]),
         )
 

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import logging
+import math
 import os
 import sys
 from enum import Enum
@@ -16,6 +17,19 @@ class Error(Exception):
 
 class ConfigFileNotFoundError(Error):
     """File could not be found on disk."""
+
+
+def _positive_duration(value: Any, name: str) -> float:
+    """Parse a finite, positive duration in seconds."""
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be a positive duration in seconds")
+    try:
+        duration = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be a positive duration in seconds") from error
+    if not math.isfinite(duration) or duration <= 0:
+        raise ValueError(f"{name} must be a positive duration in seconds")
+    return duration
 
 
 WG_CONFIG_OS_ENV = "WGKEX_CONFIG_FILE"
@@ -171,6 +185,42 @@ class MQTT:
             broker_port=int(mqtt_cfg.get("broker_port", cls.broker_port)),
             keepalive=int(mqtt_cfg.get("keepalive", cls.keepalive)),
         )
+
+
+@dataclasses.dataclass(frozen=True)
+class Cleanup:
+    """Worker peer cleanup timing in seconds."""
+
+    interval: float = 3600
+    parker_stale_timeout: float = 300
+    legacy_stale_timeout: float = 10800
+    initial_handshake_grace: float = 600
+
+    @classmethod
+    def from_dict(cls, cleanup_cfg: Dict[str, Any]) -> "Cleanup":
+        if not isinstance(cleanup_cfg, dict):
+            raise ValueError("cleanup must be a mapping")
+        return cls(
+            interval=_positive_duration(
+                cleanup_cfg.get("interval", cls.interval), "cleanup.interval"
+            ),
+            parker_stale_timeout=_positive_duration(
+                cleanup_cfg.get("parker_stale_timeout", cls.parker_stale_timeout),
+                "cleanup.parker_stale_timeout",
+            ),
+            legacy_stale_timeout=_positive_duration(
+                cleanup_cfg.get("legacy_stale_timeout", cls.legacy_stale_timeout),
+                "cleanup.legacy_stale_timeout",
+            ),
+            initial_handshake_grace=_positive_duration(
+                cleanup_cfg.get("initial_handshake_grace", cls.initial_handshake_grace),
+                "cleanup.initial_handshake_grace",
+            ),
+        )
+
+    def stale_timeout(self, parker: bool) -> float:
+        """Return the stale timeout for the selected worker mode."""
+        return self.parker_stale_timeout if parker else self.legacy_stale_timeout
 
 
 @dataclasses.dataclass
@@ -389,6 +439,7 @@ class Config:
     domain_prefixes: List[str]
     workers: Workers
     parker: Parker
+    cleanup: Cleanup
     external_name: Optional[str]
     mqtt: MQTT
     broker_listen: BrokerListen
@@ -410,6 +461,7 @@ class Config:
             cfg.get("workers", {}), cfg.get("sticky_worker_tolerance", 10)
         )
         parker = Parker.from_dict(cfg.get("parker", {}))
+        cleanup = Cleanup.from_dict(cfg.get("cleanup", {}))
         broker_signing_key = cfg.get("broker_signing_key", None)
 
         netbox_cfg = None
@@ -428,6 +480,7 @@ class Config:
             workers=workers_cfg,
             external_name=cfg.get("externalName"),
             parker=parker,
+            cleanup=cleanup,
             netbox=netbox_cfg,
             broker_signing_key=broker_signing_key,
         )

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -30,8 +30,7 @@ class Worker:
         id: A unique, static ID for this worker. In Parker mode this is the
             concentrator ID sent to nodes, identifying the tunnel on the node, so it
             must never change for a given worker. If not set explicitly in the config,
-            it defaults to the worker's position in the workers map - which shifts
-            when workers are added or removed, so set it explicitly in production.
+            it defaults to the worker's position in the workers map.
         weight: The relative weight of a worker, defaults to 1.
         pop: The PoP (Point of Presence) this worker is located in
     """
@@ -42,12 +41,13 @@ class Worker:
 
     @classmethod
     def from_dict(cls, worker_cfg: Dict[str, Any]) -> "Worker":
-        # An explicit but empty key (e.g. "weight:") parses to None in YAML
-        # and must fall back to the default like a missing key.
+        worker_id = int(worker_cfg["id"])
+        if not 0 <= worker_id <= 2**32 - 1:
+            raise ValueError("Worker ID must be an unsigned 32-bit integer")
         return cls(
-            weight=int(worker_cfg.get("weight") or 1),
+            weight=int(1 if worker_cfg.get("weight") is None else worker_cfg["weight"]),
             pop=worker_cfg.get("pop") or "",
-            id=int(worker_cfg["id"]),
+            id=worker_id,
         )
 
 
@@ -412,11 +412,11 @@ class Config:
         parker = Parker.from_dict(cfg.get("parker", {}))
         broker_signing_key = cfg.get("broker_signing_key", None)
 
-        # broker_signing_key and netbox are broker-only settings, but the
-        # parker section is shared with workers, so their presence is
-        # enforced by the broker (signer.py / _load_parker_ipam), not here.
         netbox_cfg = None
-        if isinstance(cfg.get("netbox"), dict):
+        if isinstance(cfg.get("netbox"), dict) and {
+            "url",
+            "api_key",
+        }.issubset(cfg["netbox"]):
             netbox_cfg = Netbox.from_dict(cfg["netbox"])
 
         return cls(

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -410,17 +410,11 @@ class Config:
         parker = Parker.from_dict(cfg.get("parker", {}))
         broker_signing_key = cfg.get("broker_signing_key", None)
 
-        if parker.enabled and broker_signing_key is None:
-            raise ValueError(
-                "Parker is enabled, but no broker_signing_key is set in the config file"
-            )
-
+        # broker_signing_key and netbox are broker-only settings, but the
+        # parker section is shared with workers, so their presence is
+        # enforced by the broker (signer.py / _load_parker_ipam), not here.
         netbox_cfg = None
-        if parker.enabled and parker.ipam == Parker.IPAM.NETBOX:
-            if "netbox" not in cfg or not isinstance(cfg["netbox"], dict):
-                raise ValueError(
-                    "Parker is enabled with NetBox IPAM, but no netbox config is set in the config file"
-                )
+        if isinstance(cfg.get("netbox"), dict):
             netbox_cfg = Netbox.from_dict(cfg["netbox"])
 
         return cls(

--- a/wgkex/config/config.py
+++ b/wgkex/config/config.py
@@ -27,7 +27,11 @@ class Worker:
     """A representation of the values of the 'workers' dict in the configuration file.
 
     Attributes:
-        id: A unique, as-static-as-possible ID for this worker.
+        id: A unique, static ID for this worker. In Parker mode this is the
+            concentrator ID sent to nodes, identifying the tunnel on the node, so it
+            must never change for a given worker. If not set explicitly in the config,
+            it defaults to the worker's position in the workers map - which shifts
+            when workers are added or removed, so set it explicitly in production.
         weight: The relative weight of a worker, defaults to 1.
         pop: The PoP (Point of Presence) this worker is located in
     """
@@ -41,7 +45,7 @@ class Worker:
         return cls(
             weight=int(worker_cfg.get("weight", 1)),
             pop=worker_cfg.get("pop", ""),
-            id=worker_cfg["id"],
+            id=int(worker_cfg["id"]),
         )
 
 
@@ -68,6 +72,12 @@ class Workers:
             key: Worker.from_dict({"id": id, **value})
             for (id, (key, value)) in enumerate(workers_cfg.items(), start=1)
         }
+
+        ids = [worker.id for worker in d.values()]
+        if len(set(ids)) != len(ids):
+            raise ValueError(
+                "Worker IDs must be unique. Set explicit unique 'id' values in the workers config."
+            )
 
         total = 0
         # add "empty" PoP to set to support dynamically added workers

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -130,21 +130,57 @@ class TestConfig(unittest.TestCase):
                         config.get_config()
                 config._parsed_config = None
 
-    def test_worker_with_explicit_null_weight_defaults_to_one(self):
-        """An explicit but empty 'weight:'/'pop:' key parses to None in YAML
-        and must fall back to the defaults like a missing key."""
-        workers = config.Workers.from_dict(
-            {"gw04": {"weight": None, "pop": None}}, 10
-        )
-        worker = workers.get("gw04")
-        self.assertEqual(worker.weight, 1)
-        self.assertEqual(worker.pop, "")
-
     def test_worker_tolerance_bounds_are_validated(self):
         for tolerance in (-1, 101):
             with self.subTest(tolerance=tolerance):
                 with self.assertRaisesRegex(ValueError, "between 0 and 100"):
                     config.Workers.from_dict({}, tolerance)
+
+    def test_worker_ids_are_stable_unique_integers(self):
+        workers = config.Workers.from_dict(
+            {
+                "first": {"id": "42"},
+                "second": {},
+            },
+            10,
+        )
+        self.assertEqual(workers.get("first").id, 42)
+        self.assertEqual(workers.get("second").id, 2)
+
+        with self.assertRaisesRegex(ValueError, "Worker IDs must be unique"):
+            config.Workers.from_dict(
+                {
+                    "first": {"id": 2},
+                    "second": {},
+                },
+                10,
+            )
+
+        self.assertEqual(
+            config.Workers.from_dict(
+                {"worker": {"id": 2**32 - 1}},
+                10,
+            )
+            .get("worker")
+            .id,
+            2**32 - 1,
+        )
+        for worker_id in (-1, 2**32):
+            with (
+                self.subTest(worker_id=worker_id),
+                self.assertRaisesRegex(ValueError, "unsigned 32-bit"),
+            ):
+                config.Workers.from_dict({"worker": {"id": worker_id}}, 10)
+
+    def test_worker_explicit_null_values_use_defaults(self):
+        workers = config.Workers.from_dict(
+            {"worker": {"weight": None, "pop": None}}, 10
+        )
+        self.assertEqual(workers.get("worker").weight, 1)
+        self.assertEqual(workers.get("worker").pop, "")
+
+        workers = config.Workers.from_dict({"worker": {"weight": 0}}, 10)
+        self.assertEqual(workers.get("worker").weight, 0)
 
     def test_parker_prefix_structure_validation(self):
         invalid_configs = [
@@ -204,10 +240,7 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             config.Parker.from_dict(parker)
 
-    def test_parker_config_without_broker_credentials_parses(self):
-        """broker_signing_key and netbox are broker-only settings; a worker
-        sharing the parker section must be able to load its config without
-        them."""
+    def test_worker_parker_config_does_not_require_broker_credentials(self):
         cfg = _config_dict()
         cfg["parker"] = _parker_dict()
         parsed = config.Config.from_dict(cfg)
@@ -215,9 +248,16 @@ class TestConfig(unittest.TestCase):
         self.assertIsNone(parsed.broker_signing_key)
         self.assertIsNone(parsed.netbox)
 
+        cfg["netbox"] = {}
+        parsed = config.Config.from_dict(cfg)
+        self.assertIsNone(parsed.netbox)
+
         cfg["broker_signing_key"] = "key"
         cfg["parker"]["ipam"] = "netbox"
         cfg["parker"]["prefixes"]["ipv6"]["netbox_filter"] = {"role": "wgkex"}
+        parsed = config.Config.from_dict(cfg)
+        self.assertIsNone(parsed.netbox)
+
         cfg["netbox"] = {"url": "https://netbox", "api_key": "token"}
         parsed = config.Config.from_dict(cfg)
         self.assertEqual(parsed.netbox.url, "https://netbox")

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -130,6 +130,16 @@ class TestConfig(unittest.TestCase):
                         config.get_config()
                 config._parsed_config = None
 
+    def test_worker_with_explicit_null_weight_defaults_to_one(self):
+        """An explicit but empty 'weight:'/'pop:' key parses to None in YAML
+        and must fall back to the defaults like a missing key."""
+        workers = config.Workers.from_dict(
+            {"gw04": {"weight": None, "pop": None}}, 10
+        )
+        worker = workers.get("gw04")
+        self.assertEqual(worker.weight, 1)
+        self.assertEqual(worker.pop, "")
+
     def test_worker_tolerance_bounds_are_validated(self):
         for tolerance in (-1, 101):
             with self.subTest(tolerance=tolerance):

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -194,18 +194,20 @@ class TestConfig(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             config.Parker.from_dict(parker)
 
-    def test_parker_config_requires_signing_and_netbox_credentials(self):
+    def test_parker_config_without_broker_credentials_parses(self):
+        """broker_signing_key and netbox are broker-only settings; a worker
+        sharing the parker section must be able to load its config without
+        them."""
         cfg = _config_dict()
         cfg["parker"] = _parker_dict()
-        with self.assertRaisesRegex(ValueError, "broker_signing_key"):
-            config.Config.from_dict(cfg)
+        parsed = config.Config.from_dict(cfg)
+        self.assertTrue(parsed.parker.enabled)
+        self.assertIsNone(parsed.broker_signing_key)
+        self.assertIsNone(parsed.netbox)
 
         cfg["broker_signing_key"] = "key"
         cfg["parker"]["ipam"] = "netbox"
         cfg["parker"]["prefixes"]["ipv6"]["netbox_filter"] = {"role": "wgkex"}
-        with self.assertRaisesRegex(ValueError, "no netbox config"):
-            config.Config.from_dict(cfg)
-
         cfg["netbox"] = {"url": "https://netbox", "api_key": "token"}
         parsed = config.Config.from_dict(cfg)
         self.assertEqual(parsed.netbox.url, "https://netbox")

--- a/wgkex/config/config_test.py
+++ b/wgkex/config/config_test.py
@@ -182,6 +182,43 @@ class TestConfig(unittest.TestCase):
         workers = config.Workers.from_dict({"worker": {"weight": 0}}, 10)
         self.assertEqual(workers.get("worker").weight, 0)
 
+    def test_cleanup_defaults_and_mode_timeouts(self):
+        cleanup = config.Cleanup.from_dict({})
+        self.assertEqual(cleanup.interval, 3600)
+        self.assertEqual(cleanup.stale_timeout(True), 300)
+        self.assertEqual(cleanup.stale_timeout(False), 10800)
+        self.assertEqual(cleanup.initial_handshake_grace, 600)
+
+        cfg = _config_dict()
+        cfg["cleanup"] = {
+            "interval": 30,
+            "parker_stale_timeout": 600,
+            "legacy_stale_timeout": 7200,
+            "initial_handshake_grace": 900,
+        }
+        parsed = config.Config.from_dict(cfg)
+        self.assertEqual(parsed.cleanup.interval, 30)
+        self.assertEqual(parsed.cleanup.stale_timeout(True), 600)
+        self.assertEqual(parsed.cleanup.stale_timeout(False), 7200)
+        self.assertEqual(parsed.cleanup.initial_handshake_grace, 900)
+
+    def test_cleanup_durations_are_positive_and_finite(self):
+        fields = (
+            "interval",
+            "parker_stale_timeout",
+            "legacy_stale_timeout",
+            "initial_handshake_grace",
+        )
+        for field in fields:
+            for value in (0, -1, True, "invalid", float("inf"), None):
+                with (
+                    self.subTest(field=field, value=value),
+                    self.assertRaisesRegex(ValueError, field),
+                ):
+                    config.Cleanup.from_dict({field: value})
+        with self.assertRaisesRegex(ValueError, "mapping"):
+            config.Cleanup.from_dict([])  # type: ignore
+
     def test_parker_prefix_structure_validation(self):
         invalid_configs = [
             {"enabled": True, "464xlat": True, "ipam": "json"},

--- a/wgkex/worker/BUILD
+++ b/wgkex/worker/BUILD
@@ -3,6 +3,20 @@ load("@pip//:requirements.bzl", "requirement")
 
 
 py_library(
+    name = "peer_state",
+    srcs = ["peer_state.py"],
+    visibility = ["//visibility:public"],
+)
+
+py_test(
+    name = "peer_state_test",
+    srcs = ["peer_state_test.py"],
+    deps = [":peer_state"],
+    size = "small",
+)
+
+
+py_library(
     name = "netlink",
     srcs = ["netlink.py"],
     visibility = ["//visibility:public"],
@@ -13,6 +27,7 @@ py_library(
        "//wgkex/common:utils",
        "//wgkex/common:logger",
        "//wgkex/config:config",
+       ":peer_state",
     ],
 )
 
@@ -42,6 +57,7 @@ py_library(
        "//wgkex/config:config",
        ":msg_queue",
        ":netlink",
+       ":peer_state",
     ],
 )
 
@@ -62,6 +78,7 @@ py_binary(
     deps = [
        ":mqtt",
        ":msg_queue",
+       ":peer_state",
        "//wgkex/config:config",
        "//wgkex/common:logger",
     ],
@@ -85,6 +102,7 @@ py_library(
     deps = [
        "//wgkex/common:logger",
        ":netlink",
+       ":peer_state",
     ],
 )
 
@@ -93,6 +111,8 @@ py_test(
     srcs = ["msg_queue_test.py"],
     deps = [
        ":msg_queue",
+       ":netlink",
+       ":peer_state",
        requirement("mock"),
     ],
     size="small",

--- a/wgkex/worker/app.py
+++ b/wgkex/worker/app.py
@@ -3,7 +3,6 @@
 import signal
 import sys
 import threading
-import time
 from typing import Text
 
 from wgkex.common import logger
@@ -12,8 +11,7 @@ from wgkex.config import config
 from wgkex.worker import mqtt
 from wgkex.worker.msg_queue import watch_queue
 from wgkex.worker.netlink import wg_flush_stale_peers
-
-_CLEANUP_TIME = 3600
+from wgkex.worker.peer_state import PeerMutationCoordinator, peer_mutations
 
 
 class Error(Exception):
@@ -36,20 +34,51 @@ class InvalidDomain(Error):
     """If the domains is invalid and is not listed in the configuration file."""
 
 
-def flush_workers(parker: bool, domain: Text) -> None:
-    """Calls peer flush every _CLEANUP_TIME interval."""
-    while True:
+def flush_workers(
+    exit_event: threading.Event,
+    parker: bool,
+    domain: Text,
+    cleanup: config.Cleanup,
+    parker_prefix_length: int = 63,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+) -> None:
+    """Flush stale peers on an interruptible interval until shutdown."""
+    while not exit_event.wait(cleanup.interval):
         try:
-            time.sleep(_CLEANUP_TIME)
-            logger.info(f"Running cleanup task for {domain}")
-            logger.info("Cleaned up domains: %s", wg_flush_stale_peers(parker, domain))
-        except Exception as e:
-            # Don't crash the thread when an exception is encountered
-            logger.error(f"Exception during cleanup task for {domain}:")
-            logger.error(e)
+            logger.info("Running cleanup task domain=%s parker=%s", domain, parker)
+            results = wg_flush_stale_peers(
+                parker,
+                domain,
+                stale_timeout=cleanup.stale_timeout(parker),
+                initial_handshake_grace=cleanup.initial_handshake_grace,
+                parker_prefix_length=parker_prefix_length,
+                coordinator=coordinator,
+            )
+            logger.info(
+                "Cleanup task completed domain=%s parker=%s selected=%s "
+                "deleted=%s deferred=%s failed=%s",
+                domain,
+                parker,
+                len(results),
+                sum(result.status == "deleted" for result in results),
+                sum(result.status == "deferred" for result in results),
+                sum(result.status == "failed" for result in results),
+            )
+        except Exception as error:
+            logger.error(
+                "Cleanup sweep failed domain=%s parker=%s",
+                domain,
+                parker,
+                exc_info=error,
+            )
 
 
-def clean_up_worker(parker: bool) -> None:
+def clean_up_worker(
+    parker: bool,
+    exit_event: threading.Event,
+    worker_config: config.Config,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+) -> list[threading.Thread]:
     """Wraps flush_workers in a thread for all given domains.
 
     Arguments:
@@ -57,15 +86,25 @@ def clean_up_worker(parker: bool) -> None:
     """
     if parker:
         thread = threading.Thread(
-            target=flush_workers, args=(parker, "parker"), daemon=True
+            target=flush_workers,
+            args=(
+                exit_event,
+                parker,
+                "parker",
+                worker_config.cleanup,
+                worker_config.parker.prefixes.ipv6.length,
+                coordinator,
+            ),
+            name="peer-cleanup-parker",
         )
         thread.start()
-        return
+        return [thread]
 
-    domains = config.get_config().domains
-    prefixes = config.get_config().domain_prefixes
+    domains = worker_config.domains
+    prefixes = worker_config.domain_prefixes
     logger.debug("Cleaning up the following domains: %s", domains)
     cleanup_counter = 0
+    threads = []
     # ToDo: do we need a check if every domain got gleaned?
     for prefix in prefixes:
         for domain in domains:
@@ -82,15 +121,26 @@ def clean_up_worker(parker: bool) -> None:
                     )
                     continue
                 thread = threading.Thread(
-                    target=flush_workers, args=(parker, cleaned_domain), daemon=True
+                    target=flush_workers,
+                    args=(
+                        exit_event,
+                        parker,
+                        cleaned_domain,
+                        worker_config.cleanup,
+                        63,
+                        coordinator,
+                    ),
+                    name=f"peer-cleanup-{cleaned_domain}",
                 )
                 thread.start()
+                threads.append(thread)
     if cleanup_counter < len(domains):
         logger.error(
             "Not every domain got cleaned. Check domains %s for missing prefixes %s",
             repr(domains),
             repr(prefixes),
         )
+    return threads
 
 
 def check_all_domains_unique(domains, prefixes):
@@ -131,18 +181,18 @@ def main():
     def on_exit(sig_number, stack_frame) -> None:
         logger.info("Shutting down...")
         exit_event.set()
-        time.sleep(2)
         sys.exit()
 
     signal.signal(signal.SIGINT, on_exit)
     signal.signal(signal.SIGTERM, on_exit)
 
-    parker_enabled = config.get_config().parker.enabled
+    worker_config = config.get_config()
+    parker_enabled = worker_config.parker.enabled
     if parker_enabled:
         logger.info("Parker mode is enabled")
     else:
-        domains = config.get_config().domains
-        prefixes = config.get_config().domain_prefixes
+        domains = worker_config.domains
+        prefixes = worker_config.domain_prefixes
         if not domains:
             raise DomainsNotInConfig("Could not locate domains in configuration.")
         if not check_all_domains_unique(domains, prefixes):
@@ -151,9 +201,19 @@ def main():
             if not is_valid_domain(domain):
                 raise InvalidDomain(f"Domain {domain} has invalid prefix.")
 
-    clean_up_worker(parker_enabled)
-    watch_queue(parker_enabled)
-    mqtt.connect(exit_event)
+    cleanup_threads = clean_up_worker(parker_enabled, exit_event, worker_config)
+    queue_thread = watch_queue(
+        parker_enabled,
+        exit_event,
+        parker_prefix_length=worker_config.parker.prefixes.ipv6.length,
+        initial_handshake_grace=worker_config.cleanup.initial_handshake_grace,
+    )
+    try:
+        mqtt.connect(exit_event)
+    finally:
+        exit_event.set()
+        for thread in [queue_thread, *cleanup_threads]:
+            thread.join()
 
 
 if __name__ == "__main__":

--- a/wgkex/worker/app.py
+++ b/wgkex/worker/app.py
@@ -87,7 +87,7 @@ def clean_up_worker(parker: bool) -> None:
                 thread.start()
     if cleanup_counter < len(domains):
         logger.error(
-            "Not every domain got cleaned. Check domains for missing prefixes",
+            "Not every domain got cleaned. Check domains %s for missing prefixes %s",
             repr(domains),
             repr(prefixes),
         )

--- a/wgkex/worker/app_test.py
+++ b/wgkex/worker/app_test.py
@@ -1,147 +1,121 @@
-"""Unit tests for app.py"""
+"""Unit tests for the worker application lifecycle."""
 
 import threading
 import unittest
-from time import sleep
 
 import mock
 
+from wgkex.config import config
 from wgkex.worker import app
 
 
-def _get_config_mock(domains=None, parker=None):
+def _get_config_mock(domains=None, parker_enabled=False):
     test_prefixes = ["_TEST_PREFIX_", "_TEST_PREFIX2_"]
-    config_mock = mock.MagicMock()
-    if parker:
-        config_mock.parker = parker
-    else:
-        config_mock.parker.enabled = False
-    config_mock.domains = (
+    worker_config = mock.MagicMock()
+    worker_config.parker.enabled = parker_enabled
+    worker_config.parker.prefixes.ipv6.length = 63
+    worker_config.cleanup = config.Cleanup(interval=0.01)
+    worker_config.domains = (
         domains if domains is not None else [f"{test_prefixes[1]}domain.one"]
     )
-    config_mock.domain_prefixes = test_prefixes
-    return config_mock
+    worker_config.domain_prefixes = test_prefixes
+    return worker_config
 
 
 class AppTest(unittest.TestCase):
-    """unittest.TestCase class"""
-
-    def setUp(self) -> None:
-        """set up unittests"""
-        app._CLEANUP_TIME = 0
-
     def test_unique_domains_success(self):
-        """Ensure domain suffixes are unique."""
-        test_prefixes = ["TEST_PREFIX_", "TEST_PREFIX2_"]
-        test_domains = [
-            "TEST_PREFIX_DOMAINSUFFIX1",
-            "TEST_PREFIX_DOMAINSUFFIX2",
-            "TEST_PREFIX2_DOMAINSUFFIX3",
-        ]
         self.assertTrue(
-            app.check_all_domains_unique(test_domains, test_prefixes),
-            "unique domains are not detected unique",
+            app.check_all_domains_unique(
+                ["TEST_PREFIX_ONE", "TEST_PREFIX2_TWO"],
+                ["TEST_PREFIX_", "TEST_PREFIX2_"],
+            )
         )
 
     def test_unique_domains_fail(self):
-        """Ensure domain suffixes are not unique."""
-        test_prefixes = ["TEST_PREFIX_", "TEST_PREFIX2_"]
-        test_domains = [
-            "TEST_PREFIX_DOMAINSUFFIX1",
-            "TEST_PREFIX_DOMAINSUFFIX2",
-            "TEST_PREFIX2_DOMAINSUFFIX1",
-        ]
         self.assertFalse(
-            app.check_all_domains_unique(test_domains, test_prefixes),
-            "non-unique domains are detected as unique",
+            app.check_all_domains_unique(
+                ["TEST_PREFIX_SAME", "TEST_PREFIX2_SAME"],
+                ["TEST_PREFIX_", "TEST_PREFIX2_"],
+            )
         )
 
-    def test_unique_domains_not_list(self):
-        """Ensure domain prefixes are a list."""
-        test_prefixes = "TEST_PREFIX_, TEST_PREFIX2_"
-        test_domains = [
-            "TEST_PREFIX_DOMAINSUFFIX1",
-            "TEST_PREFIX_DOMAINSUFFIX2",
-            "TEST_PREFIX2_DOMAINSUFFIX1",
-        ]
+    def test_unique_domains_validates_prefixes(self):
         with self.assertRaises(TypeError):
-            app.check_all_domains_unique(test_domains, test_prefixes)
+            app.check_all_domains_unique(["TEST_PREFIX_ONE"], "TEST_PREFIX_")
+        with self.assertRaises(app.PrefixesNotInConfig):
+            app.check_all_domains_unique(["TEST_PREFIX_ONE"], [])
 
-    @mock.patch.object(app.config, "get_config")
-    @mock.patch.object(app.mqtt, "connect", autospec=True)
-    def test_main_success(self, connect_mock, config_mock):
-        """Ensure we can execute main."""
-        connect_mock.return_value = None
-        config_mock.return_value = _get_config_mock()
-        with mock.patch.object(app, "flush_workers", return_value=None):
-            app.main()
-            connect_mock.assert_called()
-
-    @mock.patch.object(app.config, "get_config")
-    @mock.patch.object(app.mqtt, "connect", autospec=True)
-    def test_main_fails_no_domain(self, connect_mock, config_mock):
-        """Ensure we fail when domains are not configured."""
-        config_mock.return_value = _get_config_mock(domains=[])
-        connect_mock.return_value = None
-        with self.assertRaises(app.DomainsNotInConfig):
-            app.main()
-
-    @mock.patch.object(app.config, "get_config")
-    @mock.patch.object(app.mqtt, "connect", autospec=True)
-    def test_main_fails_bad_domain(self, connect_mock, config_mock):
-        """Ensure we fail when domains are badly formatted."""
-        config_mock.return_value = _get_config_mock(domains=["cant_split_domain"])
-        connect_mock.return_value = None
-        with self.assertRaises(app.InvalidDomain):
-            app.main()
-        connect_mock.assert_not_called()
-
-    @mock.patch.object(app, "_CLEANUP_TIME", 1)
     @mock.patch.object(app, "wg_flush_stale_peers")
-    def test_flush_workers_doesnt_throw(self, wg_flush_mock):
-        """Ensure the flush_workers thread doesn't throw and exit if it encounters an exception."""
-        wg_flush_mock.side_effect = AttributeError(
-            "'NoneType' object has no attribute 'get'"
+    def test_flush_workers_uses_configured_timing_and_stops(self, flush):
+        flush.return_value = [
+            mock.Mock(status="deleted"),
+            mock.Mock(status="deferred"),
+            mock.Mock(status="failed"),
+        ]
+        exit_event = mock.MagicMock()
+        exit_event.wait.side_effect = [False, True]
+        cleanup = config.Cleanup(
+            interval=12,
+            parker_stale_timeout=345,
+            initial_handshake_grace=678,
         )
 
+        app.flush_workers(exit_event, True, "parker", cleanup, 62)
+
+        self.assertEqual(exit_event.wait.call_args_list, [mock.call(12), mock.call(12)])
+        flush.assert_called_once_with(
+            True,
+            "parker",
+            stale_timeout=345,
+            initial_handshake_grace=678,
+            parker_prefix_length=62,
+            coordinator=mock.ANY,
+        )
+
+    @mock.patch.object(
+        app, "wg_flush_stale_peers", side_effect=[RuntimeError("dump failed"), []]
+    )
+    def test_flush_workers_retries_next_sweep(self, flush):
+        exit_event = mock.MagicMock()
+        exit_event.wait.side_effect = [False, False, True]
+
+        app.flush_workers(exit_event, False, "domain", config.Cleanup(interval=1))
+
+        self.assertEqual(flush.call_count, 2)
+
+    def test_flush_workers_shutdown_interrupts_wait(self):
+        exit_event = threading.Event()
         thread = threading.Thread(
-            target=app.flush_workers, args=(False, "dummy_domain"), daemon=True
+            target=app.flush_workers,
+            args=(
+                exit_event,
+                False,
+                "domain",
+                config.Cleanup(interval=3600),
+            ),
         )
         thread.start()
-
-        i = 0
-        while i < 20 and not wg_flush_mock.called:
-            i += 1
-            sleep(0.1)
-
-        wg_flush_mock.assert_called()
-        # Assert that the thread hasn't crashed and is still running
-        self.assertTrue(thread.is_alive())
-        # If Python would allow it without writing custom signalling, this would be the place to stop the thread again
+        exit_event.set()
+        thread.join(timeout=1)
+        self.assertFalse(thread.is_alive())
 
     @mock.patch.object(app.threading, "Thread")
     def test_cleanup_schedules_parker_and_legacy_domains(self, thread):
-        app.clean_up_worker(True)
-        thread.assert_called_once_with(
-            target=app.flush_workers, args=(True, "parker"), daemon=True
-        )
+        parker_config = _get_config_mock(parker_enabled=True)
+        exit_event = threading.Event()
+        threads = app.clean_up_worker(True, exit_event, parker_config)
+        self.assertEqual(threads, [thread.return_value])
+        self.assertEqual(thread.call_args.kwargs["name"], "peer-cleanup-parker")
         thread.return_value.start.assert_called_once()
 
         thread.reset_mock()
-        with (
-            mock.patch.object(
-                app.config,
-                "get_config",
-                return_value=_get_config_mock(
-                    domains=["_TEST_PREFIX_domain.one", "unmatched"]
-                ),
-            ),
-            mock.patch.object(app.logger, "error") as error,
-        ):
-            app.clean_up_worker(False)
-        thread.assert_called_once_with(
-            target=app.flush_workers, args=(False, "domain.one"), daemon=True
+        legacy_config = _get_config_mock(
+            domains=["_TEST_PREFIX_domain.one", "unmatched"]
         )
+        with mock.patch.object(app.logger, "error") as error:
+            threads = app.clean_up_worker(False, exit_event, legacy_config)
+        self.assertEqual(threads, [thread.return_value])
+        self.assertEqual(thread.call_args.kwargs["name"], "peer-cleanup-domain.one")
         thread.return_value.start.assert_called_once()
         error.assert_called_once_with(
             "Not every domain got cleaned. Check domains %s for missing prefixes %s",
@@ -150,8 +124,55 @@ class AppTest(unittest.TestCase):
         )
 
     @mock.patch.object(app.config, "get_config")
-    def test_main_parker_registers_shutdown_and_starts_components(self, config_mock):
-        config_mock.return_value = _get_config_mock(parker=mock.MagicMock(enabled=True))
+    @mock.patch.object(app.mqtt, "connect")
+    @mock.patch.object(app, "watch_queue")
+    @mock.patch.object(app, "clean_up_worker")
+    def test_main_starts_and_joins_worker_threads(
+        self, cleanup, watch_queue, connect, get_config
+    ):
+        worker_config = _get_config_mock(parker_enabled=True)
+        get_config.return_value = worker_config
+        cleanup_thread = mock.Mock()
+        queue_thread = mock.Mock()
+        cleanup.return_value = [cleanup_thread]
+        watch_queue.return_value = queue_thread
+
+        app.main()
+
+        exit_event = cleanup.call_args.args[1]
+        cleanup.assert_called_once_with(True, exit_event, worker_config)
+        watch_queue.assert_called_once_with(
+            True,
+            exit_event,
+            parker_prefix_length=63,
+            initial_handshake_grace=600,
+        )
+        connect.assert_called_once_with(exit_event)
+        self.assertTrue(exit_event.is_set())
+        queue_thread.join.assert_called_once()
+        cleanup_thread.join.assert_called_once()
+
+    @mock.patch.object(app.config, "get_config")
+    @mock.patch.object(app.mqtt, "connect")
+    def test_main_rejects_invalid_legacy_configuration(self, connect, get_config):
+        get_config.return_value = _get_config_mock(domains=[])
+        with self.assertRaises(app.DomainsNotInConfig):
+            app.main()
+        connect.assert_not_called()
+
+        get_config.return_value = _get_config_mock(
+            domains=["_TEST_PREFIX_same", "_TEST_PREFIX2_same"]
+        )
+        with self.assertRaises(app.DomainsAreNotUnique):
+            app.main()
+
+        get_config.return_value = _get_config_mock(domains=["cant_split_domain"])
+        with self.assertRaises(app.InvalidDomain):
+            app.main()
+
+    @mock.patch.object(app.config, "get_config")
+    def test_signal_sets_exit_event(self, get_config):
+        get_config.return_value = _get_config_mock(parker_enabled=True)
         callbacks = []
         with (
             mock.patch.object(
@@ -159,35 +180,15 @@ class AppTest(unittest.TestCase):
                 "signal",
                 side_effect=lambda _, callback: callbacks.append(callback),
             ),
-            mock.patch.object(app, "clean_up_worker") as cleanup,
-            mock.patch.object(app, "watch_queue") as watch_queue,
-            mock.patch.object(app.mqtt, "connect") as connect,
-        ):
-            app.main()
-
-        cleanup.assert_called_once_with(True)
-        watch_queue.assert_called_once_with(True)
-        connect.assert_called_once()
-        self.assertEqual(len(callbacks), 2)
-
-        with (
-            mock.patch.object(app.time, "sleep") as sleep,
+            mock.patch.object(app, "clean_up_worker", return_value=[]),
+            mock.patch.object(app, "watch_queue", return_value=mock.Mock()),
+            mock.patch.object(app.mqtt, "connect"),
             mock.patch.object(app.sys, "exit") as exit_process,
         ):
-            callbacks[0](app.signal.SIGINT, None)
-        sleep.assert_called_once_with(2)
-        exit_process.assert_called_once()
-
-    @mock.patch.object(app.config, "get_config")
-    def test_main_rejects_duplicate_stripped_domains(self, config_mock):
-        config_mock.return_value = _get_config_mock(
-            domains=["_TEST_PREFIX_same", "_TEST_PREFIX2_same"]
-        )
-        with (
-            mock.patch.object(app.signal, "signal"),
-            self.assertRaises(app.DomainsAreNotUnique),
-        ):
             app.main()
+            callbacks[0](app.signal.SIGINT, None)
+
+        exit_process.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/wgkex/worker/app_test.py
+++ b/wgkex/worker/app_test.py
@@ -128,18 +128,26 @@ class AppTest(unittest.TestCase):
         thread.return_value.start.assert_called_once()
 
         thread.reset_mock()
-        with mock.patch.object(
-            app.config,
-            "get_config",
-            return_value=_get_config_mock(
-                domains=["_TEST_PREFIX_domain.one", "unmatched"]
+        with (
+            mock.patch.object(
+                app.config,
+                "get_config",
+                return_value=_get_config_mock(
+                    domains=["_TEST_PREFIX_domain.one", "unmatched"]
+                ),
             ),
+            mock.patch.object(app.logger, "error") as error,
         ):
             app.clean_up_worker(False)
         thread.assert_called_once_with(
             target=app.flush_workers, args=(False, "domain.one"), daemon=True
         )
         thread.return_value.start.assert_called_once()
+        error.assert_called_once_with(
+            "Not every domain got cleaned. Check domains %s for missing prefixes %s",
+            repr(["_TEST_PREFIX_domain.one", "unmatched"]),
+            repr(["_TEST_PREFIX_", "_TEST_PREFIX2_"]),
+        )
 
     @mock.patch.object(app.config, "get_config")
     def test_main_parker_registers_shutdown_and_starts_components(self, config_mock):

--- a/wgkex/worker/mqtt.py
+++ b/wgkex/worker/mqtt.py
@@ -167,19 +167,29 @@ def on_connect(client: mqtt.Client, userdata: Any, flags, rc) -> None:
         client.subscribe(topic)
 
         # Publish worker data (WG pubkeys, ports, local addresses)
-        port, public_key, link_address = get_device_data("wg-nodes")
-        data = {
-            "ExternalAddress": own_external_name,
-            "Port": port,
-            "PublicKey": public_key,
-            "LinkAddress": link_address,
-        }
-        client.publish(
-            MQTTTopics.TOPIC_PARKER_WORKER_WG_DATA.format(worker=_HOSTNAME),
-            json.dumps(data),
-            qos=1,
-            retain=True,
-        )
+        try:
+            port, public_key, link_address = get_device_data("wg-nodes")
+        except Exception as ex:
+            # Don't let the exception escape into paho's network loop, which
+            # would kill the MQTT connection for good.
+            logger.error(
+                "Could not get device data for interface wg-nodes: %s. "
+                "Skipping worker data publication",
+                ex,
+            )
+        else:
+            data = {
+                "ExternalAddress": own_external_name,
+                "Port": port,
+                "PublicKey": public_key,
+                "LinkAddress": link_address,
+            }
+            client.publish(
+                MQTTTopics.TOPIC_PARKER_WORKER_WG_DATA.format(worker=_HOSTNAME),
+                json.dumps(data),
+                qos=1,
+                retain=True,
+            )
 
     else:
         domains = get_config().domains

--- a/wgkex/worker/mqtt.py
+++ b/wgkex/worker/mqtt.py
@@ -24,6 +24,7 @@ from wgkex.worker.netlink import (
 _HOSTNAME = socket.gethostname()
 _METRICS_SEND_INTERVAL = 60
 _METRICS_SEND_INTERVAL_PARKER = 10
+_parker_worker_ready = False
 
 
 def connect(exit_event: threading.Event) -> None:
@@ -126,6 +127,32 @@ def on_disconnect(client: mqtt.Client, userdata: Any, rc):
     logger.debug("Disconnected with result code " + str(rc))
 
 
+def _publish_parker_worker_data(client: mqtt.Client, own_external_name: str) -> bool:
+    try:
+        port, public_key, link_address = get_device_data("wg-nodes")
+    except Exception as ex:
+        logger.error(
+            "Could not get device data for interface wg-nodes: %s. "
+            "Skipping worker data publication",
+            ex,
+        )
+        return False
+
+    data = {
+        "ExternalAddress": own_external_name,
+        "Port": port,
+        "PublicKey": public_key,
+        "LinkAddress": link_address,
+    }
+    client.publish(
+        MQTTTopics.TOPIC_PARKER_WORKER_WG_DATA.format(worker=_HOSTNAME),
+        json.dumps(data),
+        qos=1,
+        retain=True,
+    )
+    return True
+
+
 # The callback for when the client receives a CONNACK response from the server.
 def on_connect(client: mqtt.Client, userdata: Any, flags, rc) -> None:
     """Handles MQTT connect and subscribes to topics on connect
@@ -160,36 +187,14 @@ def on_connect(client: mqtt.Client, userdata: Any, flags, rc) -> None:
         if get_config().external_name is not None
         else _HOSTNAME
     )
+    global _parker_worker_ready
 
     if parker_enabled:
         topic = "parker/wireguard/+"
         logger.info(f"Subscribing to topic {topic}")
         client.subscribe(topic)
 
-        # Publish worker data (WG pubkeys, ports, local addresses)
-        try:
-            port, public_key, link_address = get_device_data("wg-nodes")
-        except Exception as ex:
-            # Don't let the exception escape into paho's network loop, which
-            # would kill the MQTT connection for good.
-            logger.error(
-                "Could not get device data for interface wg-nodes: %s. "
-                "Skipping worker data publication",
-                ex,
-            )
-        else:
-            data = {
-                "ExternalAddress": own_external_name,
-                "Port": port,
-                "PublicKey": public_key,
-                "LinkAddress": link_address,
-            }
-            client.publish(
-                MQTTTopics.TOPIC_PARKER_WORKER_WG_DATA.format(worker=_HOSTNAME),
-                json.dumps(data),
-                qos=1,
-                retain=True,
-            )
+        _parker_worker_ready = _publish_parker_worker_data(client, own_external_name)
 
     else:
         domains = get_config().domains
@@ -230,7 +235,12 @@ def on_connect(client: mqtt.Client, userdata: Any, flags, rc) -> None:
         topic = MQTTTopics.TOPIC_PARKER_WORKER_STATUS.format(worker=_HOSTNAME)
     else:
         topic = MQTTTopics.TOPIC_WORKER_STATUS.format(worker=_HOSTNAME)
-    client.publish(topic, 1, qos=1, retain=True)
+    client.publish(
+        topic,
+        int(_parker_worker_ready if parker_enabled else True),
+        qos=1,
+        retain=True,
+    )
 
 
 def on_message(client: mqtt.Client, userdata: Any, message: mqtt.MQTTMessage) -> None:
@@ -369,8 +379,22 @@ def publish_metrics_parker(client: mqtt.Client, topic: str) -> None:
 
     The metrics currently only consist of the number of connected peers.
     """
+    global _parker_worker_ready
+
     logger.debug("Publishing interface metrics")
     iface = "wg-nodes"
+
+    if not _parker_worker_ready:
+        own_external_name = get_config().external_name or _HOSTNAME
+        _parker_worker_ready = _publish_parker_worker_data(client, own_external_name)
+        if not _parker_worker_ready:
+            return
+        client.publish(
+            MQTTTopics.TOPIC_PARKER_WORKER_STATUS.format(worker=_HOSTNAME),
+            1,
+            qos=1,
+            retain=True,
+        )
 
     try:
         peer_count = get_connected_peers_count(iface)

--- a/wgkex/worker/mqtt_test.py
+++ b/wgkex/worker/mqtt_test.py
@@ -144,6 +144,27 @@ class MQTTTest(unittest.TestCase):
             ]
         )
 
+        # A missing wg-nodes interface must not raise into paho's loop; the
+        # worker skips the data publication but still subscribes and goes
+        # online.
+        mqtt_client_mock.reset_mock()
+        get_device_data_mock.side_effect = ValueError("no such device")
+
+        mqtt.on_connect(mqtt.mqtt.Client(), None, None, 0)
+
+        mqtt_client_mock.assert_has_calls(
+            [
+                mock.call().subscribe("parker/wireguard/+"),
+                mock.call().publish(
+                    f"parker/wireguard-worker/{hostname}/status", 1, qos=1, retain=True
+                ),
+            ]
+        )
+        published_topics = [
+            call.args[0] for call in mqtt_client_mock.return_value.publish.mock_calls
+        ]
+        self.assertNotIn(f"parker/wireguard-worker/{hostname}/data", published_topics)
+
     @mock.patch.object(mqtt, "get_config")
     @mock.patch.object(mqtt, "get_connected_peers_count")
     def test_publish_metrics_loop_success(self, conn_peers_mock, config_mock):

--- a/wgkex/worker/mqtt_test.py
+++ b/wgkex/worker/mqtt_test.py
@@ -31,6 +31,9 @@ def _get_config_mock(domains=None, mqtt=None, parker=None):
 
 
 class MQTTTest(unittest.TestCase):
+    def setUp(self) -> None:
+        mqtt._parker_worker_ready = True
+
     @mock.patch.object(mqtt.mqtt, "Client")
     @mock.patch.object(mqtt.socket, "gethostname")
     @mock.patch.object(mqtt, "get_config")
@@ -144,9 +147,6 @@ class MQTTTest(unittest.TestCase):
             ]
         )
 
-        # A missing wg-nodes interface must not raise into paho's loop; the
-        # worker skips the data publication but still subscribes and goes
-        # online.
         mqtt_client_mock.reset_mock()
         get_device_data_mock.side_effect = ValueError("no such device")
 
@@ -156,7 +156,7 @@ class MQTTTest(unittest.TestCase):
             [
                 mock.call().subscribe("parker/wireguard/+"),
                 mock.call().publish(
-                    f"parker/wireguard-worker/{hostname}/status", 1, qos=1, retain=True
+                    f"parker/wireguard-worker/{hostname}/status", 0, qos=1, retain=True
                 ),
             ]
         )
@@ -164,6 +164,28 @@ class MQTTTest(unittest.TestCase):
             call.args[0] for call in mqtt_client_mock.return_value.publish.mock_calls
         ]
         self.assertNotIn(f"parker/wireguard-worker/{hostname}/data", published_topics)
+
+        mqtt_client_mock.reset_mock()
+        get_device_data_mock.side_effect = None
+        get_device_data_mock.return_value = (51820, "456asdf=", "fe80::1")
+        with mock.patch.object(mqtt, "get_connected_peers_count", return_value=0):
+            mqtt.publish_metrics_parker(mqtt.mqtt.Client(), "parker/metrics")
+
+        mqtt_client_mock.assert_has_calls(
+            [
+                mock.call().publish(
+                    f"parker/wireguard-worker/{hostname}/data",
+                    '{"ExternalAddress": "%s", "Port": 51820, "PublicKey": "456asdf=", "LinkAddress": "fe80::1"}'
+                    % hostname,
+                    qos=1,
+                    retain=True,
+                ),
+                mock.call().publish(
+                    f"parker/wireguard-worker/{hostname}/status", 1, qos=1, retain=True
+                ),
+                mock.call().publish("parker/metrics", 0, retain=True),
+            ]
+        )
 
     @mock.patch.object(mqtt, "get_config")
     @mock.patch.object(mqtt, "get_connected_peers_count")

--- a/wgkex/worker/msg_queue.py
+++ b/wgkex/worker/msg_queue.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
 import json
 import threading
+from ipaddress import IPv6Network
 from queue import Empty, Queue
 
 from wgkex.common import logger
 from wgkex.worker.netlink import (
+    get_parker_prefixes_for_peer,
     ParkerWireGuardClient,
+    PeerMutationError,
     WireGuardClient,
     link_handler,
 )
+from wgkex.worker.peer_state import PeerMutationCoordinator, peer_mutations
 
 
 class UniqueQueue(Queue):
@@ -29,21 +33,64 @@ class UniqueQueue(Queue):
 q = UniqueQueue()
 
 
-def watch_queue(parker: bool = False) -> None:
+def watch_queue(
+    parker: bool,
+    stop_event: threading.Event,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    parker_prefix_length: int = 63,
+    initial_handshake_grace: float = 600,
+) -> threading.Thread:
     """Watches the queue for new messages."""
     logger.debug("Starting queue watcher")
-    threading.Thread(target=pick_from_queue, args=[parker], daemon=True).start()
+    thread = threading.Thread(
+        target=pick_from_queue,
+        args=(
+            parker,
+            q,
+            stop_event,
+            coordinator,
+            parker_prefix_length,
+            initial_handshake_grace,
+        ),
+        name="peer-update-queue",
+    )
+    thread.start()
+    return thread
 
 
-def _process_queue_item(item, parker: bool) -> None:
+def _process_queue_item(
+    item,
+    parker: bool,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    parker_prefix_length: int = 63,
+    initial_handshake_grace: float = 600,
+) -> None:
     if parker:
         message = json.loads(item)
+        if not isinstance(message, dict):
+            raise ValueError("Parker queue item must be an object")
+        public_key = message.get("PublicKey")
+        range6 = message.get("Range6")
+        if not isinstance(public_key, str) or not public_key:
+            raise ValueError("Parker queue item has no valid PublicKey")
+        try:
+            parsed_range6 = IPv6Network(range6)
+        except (TypeError, ValueError) as error:
+            raise ValueError("Parker queue item has no valid Range6") from error
+        if parsed_range6.prefixlen != parker_prefix_length:
+            raise ValueError(
+                "Parker queue item Range6 prefix length "
+                f"must be /{parker_prefix_length}"
+            )
+        previous_ranges6 = tuple(
+            get_parker_prefixes_for_peer("wg-nodes", public_key, parker_prefix_length)
+        )
         client = ParkerWireGuardClient(
-            # TODO use shared data class
-            public_key=message.get("PublicKey"),
-            range6=message.get("Range6"),
+            public_key=public_key,
+            range6=str(parsed_range6),
             keepalive=message.get("Keepalive"),
             remove=False,
+            previous_ranges6=previous_ranges6,
         )
         logger.info(
             "Processing queue for key %s with range %s",
@@ -52,6 +99,13 @@ def _process_queue_item(item, parker: bool) -> None:
         )
     else:
         domain, message = item
+        if (
+            not isinstance(domain, str)
+            or not domain
+            or not isinstance(message, str)
+            or not message
+        ):
+            raise ValueError("Legacy queue item has no valid domain or public key")
         logger.debug("Processing queue item %s for domain %s", message, domain)
         client = WireGuardClient(
             public_key=message,
@@ -64,13 +118,33 @@ def _process_queue_item(item, parker: bool) -> None:
             domain,
             client.lladdr,
         )
-    logger.debug(link_handler(client))
+    related_resources = (
+        [client.range6, *client.previous_ranges6]
+        if isinstance(client, ParkerWireGuardClient)
+        else None
+    )
+    with coordinator.peer_lock(client.public_key, related_resources):
+        coordinator.record_provisioned(client.public_key, initial_handshake_grace)
+        try:
+            result = link_handler(client)
+        except PeerMutationError as error:
+            if error.operation == "wireguard" and not error.operations:
+                coordinator.forget(client.public_key)
+            if error.operation.startswith("old_route:"):
+                coordinator.record_pending_parker_route(
+                    error.operation.removeprefix("old_route:")
+                )
+            raise
+        logger.debug(result)
 
 
 def pick_from_queue(
     parker: bool = False,
     work_queue: Queue = q,
     stop_event: threading.Event | None = None,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    parker_prefix_length: int = 63,
+    initial_handshake_grace: float = 600,
 ) -> None:
     """Picks a message from the queue and processes it."""
     logger.debug("Starting queue processor")
@@ -81,7 +155,13 @@ def pick_from_queue(
             continue
 
         try:
-            _process_queue_item(item, parker)
+            _process_queue_item(
+                item,
+                parker,
+                coordinator,
+                parker_prefix_length,
+                initial_handshake_grace,
+            )
         except Exception as error:
             logger.error(
                 "Failed to process queue item %r; continuing with the next item",

--- a/wgkex/worker/msg_queue_test.py
+++ b/wgkex/worker/msg_queue_test.py
@@ -7,9 +7,26 @@ from queue import Queue
 import mock
 
 from wgkex.worker import msg_queue
+from wgkex.worker import netlink
+from wgkex.worker.peer_state import PeerMutationCoordinator
+
+
+class MutableClock:
+    def __init__(self):
+        self.now = 0
+
+    def __call__(self):
+        return self.now
 
 
 class TestMessageQueue(unittest.TestCase):
+    def setUp(self):
+        self.prefixes = mock.patch.object(
+            msg_queue, "get_parker_prefixes_for_peer", return_value=[]
+        )
+        self.get_prefixes = self.prefixes.start()
+        self.addCleanup(self.prefixes.stop)
+
     @mock.patch.object(msg_queue, "link_handler")
     def test_bad_item_does_not_stop_processing_or_break_accounting(self, link_handler):
         work_queue = Queue()
@@ -70,6 +87,142 @@ class TestMessageQueue(unittest.TestCase):
         self.assertEqual(work_queue.unfinished_tasks, 0)
         self.assertEqual(link_handler.call_count, 2)
         self.assertEqual(link_handler.call_args.args[0].public_key, "second-key")
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_accepted_updates_refresh_provisioning_state(self, link_handler):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        msg_queue._process_queue_item(
+            json.dumps(
+                {
+                    "PublicKey": "key",
+                    "Range6": "2001:db8::/63",
+                    "Keepalive": 25,
+                }
+            ),
+            True,
+            coordinator,
+        )
+        self.assertTrue(coordinator.recently_provisioned("key", 600))
+        link_handler.assert_called_once()
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_parker_update_carries_and_locks_previous_prefixes(self, link_handler):
+        self.get_prefixes.return_value = ["2001:db8:1::/63"]
+        coordinator = mock.MagicMock()
+        coordinator.peer_lock.return_value.__enter__.return_value = None
+
+        msg_queue._process_queue_item(
+            json.dumps(
+                {
+                    "PublicKey": "key",
+                    "Range6": "2001:db8:2::/63",
+                    "Keepalive": 25,
+                }
+            ),
+            True,
+            coordinator,
+        )
+
+        client = link_handler.call_args.args[0]
+        self.assertEqual(client.previous_ranges6, ("2001:db8:1::/63",))
+        coordinator.peer_lock.assert_called_once_with(
+            "key", ["2001:db8:2::/63", "2001:db8:1::/63"]
+        )
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_malformed_queue_items_are_rejected(self, link_handler):
+        invalid_items = (
+            ("[]", True),
+            ('{"PublicKey":"","Range6":"2001:db8::/63"}', True),
+            ('{"PublicKey":"key","Range6":"invalid"}', True),
+            ('{"PublicKey":"key","Range6":"2001:db8::/64"}', True),
+            (("", "key"), False),
+            (("domain", ""), False),
+        )
+        for item, parker in invalid_items:
+            with self.subTest(item=item), self.assertRaises(ValueError):
+                msg_queue._process_queue_item(item, parker)
+        link_handler.assert_not_called()
+
+    @mock.patch.object(msg_queue, "link_handler")
+    def test_failed_old_route_is_queued_for_cleanup(self, link_handler):
+        client = netlink.ParkerWireGuardClient("key", "2001:db8:2::/63", False)
+        link_handler.side_effect = netlink.PeerMutationError(
+            "old_route:2001:db8:1::/63",
+            client,
+            {
+                "wireguard": netlink.OperationOutcome("updated"),
+                "route": netlink.OperationOutcome("updated"),
+            },
+            RuntimeError("route failed"),
+        )
+        coordinator = PeerMutationCoordinator()
+
+        with self.assertRaises(netlink.PeerMutationError):
+            msg_queue._process_queue_item(
+                json.dumps(
+                    {
+                        "PublicKey": "key",
+                        "Range6": "2001:db8:2::/63",
+                    }
+                ),
+                True,
+                coordinator,
+            )
+
+        self.assertEqual(
+            coordinator.pending_parker_routes(),
+            ("2001:db8:1::/63",),
+        )
+
+    def test_concurrent_update_defers_cleanup_for_same_peer(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        update_entered = threading.Event()
+        release_update = threading.Event()
+        cleanup_results = []
+        stale = netlink.StaleWireGuardPeer("key", None, "stale_handshake")
+
+        def update_peer(_):
+            update_entered.set()
+            release_update.wait(timeout=1)
+            return {}
+
+        with (
+            mock.patch.object(msg_queue, "link_handler", side_effect=update_peer),
+            mock.patch.object(
+                netlink, "find_stale_wireguard_clients", return_value=[stale]
+            ),
+            mock.patch.object(netlink, "link_handler") as delete_peer,
+        ):
+            update_thread = threading.Thread(
+                target=msg_queue._process_queue_item,
+                args=(("domain", "key"), False, coordinator),
+            )
+            update_thread.start()
+            self.assertTrue(update_entered.wait(timeout=1))
+
+            cleanup_thread = threading.Thread(
+                target=lambda: cleanup_results.extend(
+                    netlink.wg_flush_stale_peers(
+                        False,
+                        "domain",
+                        initial_handshake_grace=600,
+                        coordinator=coordinator,
+                        clock=clock,
+                    )
+                )
+            )
+            cleanup_thread.start()
+            time.sleep(0.05)
+            delete_peer.assert_not_called()
+            release_update.set()
+            update_thread.join(timeout=1)
+            cleanup_thread.join(timeout=1)
+
+        self.assertEqual(cleanup_results[0].status, "deferred")
+        delete_peer.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -260,7 +260,6 @@ def find_stale_wireguard_clients(parker: bool, wg_interface: str) -> List:
                 peer.get_attr("WGPEER_A_PUBLIC_KEY").decode("utf-8"),
                 (
                     allowed_ips[0].get("addr")  # addr contains the prefix as string
-                    # get_attr returns None when the peer has no allowed IPs.
                     if parker and (allowed_ips := peer.get_attr("WGPEER_A_ALLOWEDIPS"))
                     else None
                 ),

--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -1,12 +1,15 @@
 """Functions related to netlink manipulation for Wireguard, IPRoute and FDB on Linux."""
 
 # See https://docs.pyroute2.org/iproute.html for a documentation of the layout of netlink responses
+import errno
 import hashlib
+import ipaddress
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from textwrap import wrap
-from typing import Dict, List, Optional, Tuple, Union
+from time import time
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import pyroute2
 import pyroute2.netlink
@@ -14,8 +17,13 @@ import pyroute2.netlink.exceptions
 
 from wgkex.common import logger
 from wgkex.common.utils import mac2eui64
+from wgkex.worker.peer_state import PeerMutationCoordinator, peer_mutations
 
-_PEER_TIMEOUT_HOURS = 3
+_PARKER_STALE_TIMEOUT = 300
+_LEGACY_STALE_TIMEOUT = 10800
+_INITIAL_HANDSHAKE_GRACE = 600
+_NETLINK_DUMP_RETRIES = 1
+_ABSENT_ERRNOS = {errno.ENOENT, errno.ENODEV, errno.ESRCH}
 
 
 @dataclass
@@ -73,41 +81,225 @@ class ParkerWireGuardClient:
     range6: str
     remove: bool
     keepalive: Optional[int] = None
+    previous_ranges6: Tuple[str, ...] = ()
 
 
-def wg_flush_stale_peers(parker: bool = False, domain: str = "") -> List[Dict]:
+@dataclass(frozen=True)
+class StaleWireGuardPeer:
+    """A validated peer selected for cleanup."""
+
+    public_key: str
+    parker_prefix: Optional[str]
+    reason: str
+
+
+@dataclass(frozen=True)
+class OperationOutcome:
+    """The explicit outcome of one netlink mutation."""
+
+    status: str
+    result: Any = None
+
+
+@dataclass(frozen=True)
+class PeerCleanupResult:
+    """The explicit result of one stale peer cleanup attempt."""
+
+    public_key: str
+    status: str
+    operations: Dict[str, OperationOutcome]
+    failed_operation: Optional[str] = None
+    error: Optional[str] = None
+
+
+class PeerMutationError(RuntimeError):
+    """A peer mutation failed after zero or more successful operations."""
+
+    def __init__(
+        self,
+        operation: str,
+        client: Union[WireGuardClient, ParkerWireGuardClient],
+        operations: Dict[str, OperationOutcome],
+        cause: Exception,
+    ) -> None:
+        super().__init__(f"{operation} failed for peer {client.public_key}: {cause}")
+        self.operation = operation
+        self.client = client
+        self.operations = operations
+        self.cause = cause
+
+
+def wg_flush_stale_peers(
+    parker: bool = False,
+    domain: str = "",
+    *,
+    stale_timeout: Optional[float] = None,
+    initial_handshake_grace: float = _INITIAL_HANDSHAKE_GRACE,
+    parker_prefix_length: int = 63,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    clock: Callable[[], float] = time,
+) -> List[PeerCleanupResult]:
     """Removes stale peers.
 
     Arguments:
         domain: The domain to detect peers on.
 
     Returns:
-        The peers which we can remove.
+        The outcome for every peer selected for cleanup.
     """
+    if stale_timeout is None:
+        stale_timeout = _PARKER_STALE_TIMEOUT if parker else _LEGACY_STALE_TIMEOUT
     if parker:
-        logger.info("Searching for staleclients")
-        stale_clients = find_stale_wireguard_clients(parker, "wg-nodes")
+        retry_pending_parker_routes(
+            coordinator=coordinator,
+            prefix_length=parker_prefix_length,
+        )
+        wg_interface = "wg-nodes"
+        logger.info("Searching for stale clients interface=%s", wg_interface)
+        stale_clients = find_stale_wireguard_clients(
+            parker,
+            wg_interface,
+            stale_timeout=stale_timeout,
+            initial_handshake_grace=initial_handshake_grace,
+            parker_prefix_length=parker_prefix_length,
+            coordinator=coordinator,
+            clock=clock,
+        )
         logger.debug("Found %s stale clients: %s", len(stale_clients), stale_clients)
         stale_wireguard_clients = [
-            ParkerWireGuardClient(public_key=stale_client, range6=range6, remove=True)
-            for (stale_client, range6) in stale_clients
+            ParkerWireGuardClient(
+                public_key=stale_client.public_key,
+                range6=stale_client.parker_prefix or "",
+                remove=True,
+            )
+            for stale_client in stale_clients
         ]
     else:
-        logger.info("Searching for stale clients for %s", domain)
-        stale_clients = find_stale_wireguard_clients(parker, "wg-" + domain)
+        wg_interface = "wg-" + domain
+        logger.info(
+            "Searching for stale clients interface=%s domain=%s",
+            wg_interface,
+            domain,
+        )
+        stale_clients = find_stale_wireguard_clients(
+            parker,
+            wg_interface,
+            stale_timeout=stale_timeout,
+            initial_handshake_grace=initial_handshake_grace,
+            coordinator=coordinator,
+            clock=clock,
+        )
         logger.debug("Found %s stale clients: %s", len(stale_clients), stale_clients)
         stale_wireguard_clients = [
-            WireGuardClient(public_key=stale_client, domain=domain, remove=True)
-            for (stale_client, _) in stale_clients
+            WireGuardClient(
+                public_key=stale_client.public_key,
+                domain=domain,
+                remove=True,
+            )
+            for stale_client in stale_clients
         ]
 
-    logger.debug("Found stale WireGuard clients: %s", stale_wireguard_clients)
-    logger.info("Processing stale WireGuard clients.")
-    link_handled = [
-        link_handler(stale_client) for stale_client in stale_wireguard_clients
-    ]
-    logger.debug("Handled the following stale clients: %s", link_handled)
-    return link_handled
+    results = []
+    for client in stale_wireguard_clients:
+        related_resource = (
+            client.range6 if isinstance(client, ParkerWireGuardClient) else None
+        )
+        with coordinator.peer_lock(client.public_key, related_resource):
+            if coordinator.recently_provisioned(
+                client.public_key, initial_handshake_grace
+            ):
+                logger.info(
+                    "Deferring cleanup for recently provisioned peer "
+                    "interface=%s public_key=%s",
+                    wg_interface,
+                    client.public_key,
+                )
+                results.append(
+                    PeerCleanupResult(
+                        public_key=client.public_key,
+                        status="deferred",
+                        operations={},
+                    )
+                )
+                continue
+            current_stale_peers = find_stale_wireguard_clients(
+                parker,
+                wg_interface,
+                stale_timeout=stale_timeout,
+                initial_handshake_grace=initial_handshake_grace,
+                parker_prefix_length=parker_prefix_length,
+                coordinator=coordinator,
+                clock=clock,
+            )
+            still_stale = any(
+                stale_peer.public_key == client.public_key
+                and (not parker or stale_peer.parker_prefix == related_resource)
+                for stale_peer in current_stale_peers
+            )
+            if not still_stale:
+                logger.info(
+                    "Deferring cleanup after peer state changed "
+                    "interface=%s public_key=%s",
+                    wg_interface,
+                    client.public_key,
+                )
+                results.append(
+                    PeerCleanupResult(
+                        public_key=client.public_key,
+                        status="deferred",
+                        operations={},
+                    )
+                )
+                continue
+            try:
+                preserve_parker_route = isinstance(
+                    client, ParkerWireGuardClient
+                ) and parker_prefix_owned_by_other_peer(
+                    wg_interface,
+                    client.range6,
+                    client.public_key,
+                    parker_prefix_length,
+                )
+                operations = link_handler(
+                    client, preserve_parker_route=preserve_parker_route
+                )
+            except PeerMutationError as error:
+                logger.error(
+                    "Peer cleanup failed interface=%s public_key=%s "
+                    "operation=%s completed_operations=%s error=%s",
+                    wg_interface,
+                    client.public_key,
+                    error.operation,
+                    list(error.operations),
+                    error.cause,
+                    exc_info=error,
+                )
+                results.append(
+                    PeerCleanupResult(
+                        public_key=client.public_key,
+                        status="failed",
+                        operations=error.operations,
+                        failed_operation=error.operation,
+                        error=str(error.cause),
+                    )
+                )
+                continue
+
+            coordinator.forget(client.public_key)
+            logger.info(
+                "Peer cleanup completed interface=%s public_key=%s operations=%s",
+                wg_interface,
+                client.public_key,
+                {name: outcome.status for name, outcome in operations.items()},
+            )
+            results.append(
+                PeerCleanupResult(
+                    public_key=client.public_key,
+                    status="deleted",
+                    operations=operations,
+                )
+            )
+    return results
 
 
 ##################
@@ -115,7 +307,44 @@ def wg_flush_stale_peers(parker: bool = False, domain: str = "") -> List[Dict]:
 ##################
 
 
-def link_handler(client: Union[WireGuardClient, ParkerWireGuardClient]) -> Dict:
+def _is_absent_error(error: Exception) -> bool:
+    code = getattr(error, "code", None)
+    return isinstance(code, int) and abs(code) in _ABSENT_ERRNOS
+
+
+def _run_operation(
+    operation: str,
+    client: Union[WireGuardClient, ParkerWireGuardClient],
+    handler: Callable[[Union[WireGuardClient, ParkerWireGuardClient]], Dict],
+    operations: Dict[str, OperationOutcome],
+) -> None:
+    try:
+        result = handler(client)
+    except pyroute2.netlink.exceptions.NetlinkError as error:
+        if client.remove and _is_absent_error(error):
+            logger.info(
+                "Peer cleanup dependency already absent public_key=%s "
+                "operation=%s errno=%s",
+                client.public_key,
+                operation,
+                error.code,
+            )
+            operations[operation] = OperationOutcome(status="already_absent")
+            return
+        raise PeerMutationError(operation, client, operations.copy(), error) from error
+    except Exception as error:
+        raise PeerMutationError(operation, client, operations.copy(), error) from error
+    operations[operation] = OperationOutcome(
+        status="deleted" if client.remove else "updated",
+        result=result,
+    )
+
+
+def link_handler(
+    client: Union[WireGuardClient, ParkerWireGuardClient],
+    *,
+    preserve_parker_route: bool = False,
+) -> Dict[str, OperationOutcome]:
     """Updates fdb, route and WireGuard peers tables for a given WireGuard peer.
 
     Arguments:
@@ -123,23 +352,44 @@ def link_handler(client: Union[WireGuardClient, ParkerWireGuardClient]) -> Dict:
     Returns:
         The outcome of each operation.
     """
-    results = dict()
-    # Updates WireGuard peers.
-    results.update({"Wireguard": update_wireguard_peer(client)})
+    operations: Dict[str, OperationOutcome] = {}
     logger.debug("Handling links for %s", client)
-    try:
-        # Updates routes to the WireGuard Peer.
-        results.update({"Route": route_handler(client)})
-        logger.info("Updated route for %s", client)
-    except Exception as e:
-        # TODO(ruairi): re-raise exception here.
-        logger.error("Failed to update route for %s (%s)", client, e)
-        results.update({"Route": e})
-    if isinstance(client, WireGuardClient):
-        # Updates WireGuard FDB.
-        results.update({"Bridge FDB": bridge_fdb_handler(client)})
-        logger.debug("Updated Bridge FDB for %s", client)
-    return results
+    if client.remove:
+        # Keep the peer discoverable until every dependent object is gone.
+        if isinstance(client, WireGuardClient):
+            _run_operation("bridge_fdb", client, bridge_fdb_handler, operations)
+        if preserve_parker_route:
+            logger.info(
+                "Preserving Parker route owned by another peer "
+                "public_key=%s prefix=%s",
+                client.public_key,
+                client.range6,
+            )
+            operations["route"] = OperationOutcome(status="preserved_shared")
+        else:
+            _run_operation("route", client, route_handler, operations)
+        _run_operation("wireguard", client, update_wireguard_peer, operations)
+    else:
+        _run_operation("wireguard", client, update_wireguard_peer, operations)
+        _run_operation("route", client, route_handler, operations)
+        if isinstance(client, ParkerWireGuardClient):
+            for previous_range6 in client.previous_ranges6:
+                if previous_range6 == client.range6:
+                    continue
+                previous_client = ParkerWireGuardClient(
+                    public_key=client.public_key,
+                    range6=previous_range6,
+                    remove=True,
+                )
+                _run_operation(
+                    f"old_route:{previous_range6}",
+                    previous_client,
+                    route_handler,
+                    operations,
+                )
+        if isinstance(client, WireGuardClient):
+            _run_operation("bridge_fdb", client, bridge_fdb_handler, operations)
+    return operations
 
 
 def bridge_fdb_handler(client: WireGuardClient) -> Dict:
@@ -229,7 +479,214 @@ def route_handler(client: Union[WireGuardClient, ParkerWireGuardClient]) -> Dict
         return dict(result) if isinstance(result, dict) else {"result": result}
 
 
-def find_stale_wireguard_clients(parker: bool, wg_interface: str) -> List:
+def _wireguard_info(
+    wg: pyroute2.WireGuard,
+    wg_interface: str,
+    retries: int = _NETLINK_DUMP_RETRIES,
+) -> List:
+    for attempt in range(retries + 1):
+        try:
+            return wg.info(wg_interface)
+        except pyroute2.netlink.exceptions.NetlinkDumpInterrupted:
+            if attempt == retries:
+                raise
+            logger.warning(
+                "WireGuard netlink dump interrupted; retrying "
+                "interface=%s attempt=%s max_attempts=%s",
+                wg_interface,
+                attempt + 1,
+                retries + 1,
+            )
+    raise AssertionError("unreachable")
+
+
+def _peer_public_key(peer: pyroute2.netlink.nla) -> str:
+    public_key = peer.get_attr("WGPEER_A_PUBLIC_KEY")
+    if isinstance(public_key, bytes):
+        public_key = public_key.decode("ascii")
+    if not isinstance(public_key, str) or not public_key:
+        raise ValueError("missing or invalid public key")
+    return public_key
+
+
+def _last_handshake_seconds(peer: pyroute2.netlink.nla) -> Optional[int]:
+    handshake = peer.get_attr("WGPEER_A_LAST_HANDSHAKE_TIME")
+    if handshake is None:
+        return None
+    if not isinstance(handshake, dict):
+        raise ValueError("invalid last handshake attribute")
+    seconds = handshake.get("tv_sec")
+    if isinstance(seconds, bool) or not isinstance(seconds, int) or seconds < 0:
+        raise ValueError("invalid last handshake seconds")
+    return seconds
+
+
+def _parker_prefix(peer: pyroute2.netlink.nla, prefix_length: int) -> str:
+    allowed_ips = peer.get_attr("WGPEER_A_ALLOWEDIPS")
+    if not isinstance(allowed_ips, (list, tuple)):
+        raise ValueError("missing or invalid allowed IPs")
+
+    matches = set()
+    for allowed_ip in allowed_ips:
+        address = allowed_ip.get("addr") if isinstance(allowed_ip, dict) else None
+        if not isinstance(address, str):
+            continue
+        try:
+            network = ipaddress.ip_network(address, strict=False)
+        except ValueError:
+            continue
+        if network.version == 6 and network.prefixlen == prefix_length:
+            matches.add(str(network))
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one IPv6 /{prefix_length} Parker prefix, "
+            f"found {len(matches)}"
+        )
+    return matches.pop()
+
+
+def parker_prefix_owned_by_other_peer(
+    wg_interface: str,
+    parker_prefix: str,
+    public_key: str,
+    prefix_length: int,
+) -> bool:
+    """Return whether another current peer owns a Parker prefix."""
+    with pyroute2.WireGuard() as wg:
+        messages = _wireguard_info(wg, wg_interface)
+    for message in messages:
+        peers = message.get_attr("WGDEVICE_A_PEERS")
+        if not isinstance(peers, (list, tuple)):
+            continue
+        for peer in peers:
+            try:
+                peer_prefix = _parker_prefix(peer, prefix_length)
+            except (ValueError, AttributeError):
+                continue
+            if peer_prefix != parker_prefix:
+                continue
+            try:
+                peer_public_key = _peer_public_key(peer)
+            except (UnicodeDecodeError, ValueError, AttributeError):
+                logger.warning(
+                    "Preserving Parker route with ambiguous owner "
+                    "interface=%s prefix=%s",
+                    wg_interface,
+                    parker_prefix,
+                )
+                return True
+            if peer_public_key != public_key:
+                return True
+    return False
+
+
+def retry_pending_parker_routes(
+    *,
+    coordinator: PeerMutationCoordinator,
+    prefix_length: int,
+    wg_interface: str = "wg-nodes",
+) -> None:
+    """Retry old Parker route deletions left by partial queue updates."""
+    for prefix in coordinator.pending_parker_routes():
+        with coordinator.peer_lock("", prefix):
+            try:
+                has_owner = parker_prefix_owned_by_other_peer(
+                    wg_interface, prefix, "", prefix_length
+                )
+            except pyroute2.netlink.exceptions.NetlinkDumpInterrupted as error:
+                logger.warning(
+                    "Pending Parker route ownership check failed "
+                    "interface=%s prefix=%s error=%s",
+                    wg_interface,
+                    prefix,
+                    error,
+                )
+                continue
+            if has_owner:
+                logger.info(
+                    "Pending Parker route is owned again; preserving "
+                    "interface=%s prefix=%s",
+                    wg_interface,
+                    prefix,
+                )
+                coordinator.forget_pending_parker_route(prefix)
+                continue
+
+            operations: Dict[str, OperationOutcome] = {}
+            client = ParkerWireGuardClient(
+                public_key="pending-route-cleanup",
+                range6=prefix,
+                remove=True,
+            )
+            try:
+                _run_operation("route", client, route_handler, operations)
+            except PeerMutationError as error:
+                logger.error(
+                    "Pending Parker route cleanup failed "
+                    "interface=%s prefix=%s error=%s",
+                    wg_interface,
+                    prefix,
+                    error.cause,
+                    exc_info=error,
+                )
+                continue
+            coordinator.forget_pending_parker_route(prefix)
+            logger.info(
+                "Pending Parker route cleanup completed "
+                "interface=%s prefix=%s status=%s",
+                wg_interface,
+                prefix,
+                operations["route"].status,
+            )
+
+
+def get_parker_prefixes_for_peer(
+    wg_interface: str,
+    public_key: str,
+    prefix_length: int,
+) -> List[str]:
+    """Return all assigned Parker prefixes currently owned by a peer."""
+    with pyroute2.WireGuard() as wg:
+        messages = _wireguard_info(wg, wg_interface)
+    prefixes = set()
+    for message in messages:
+        peers = message.get_attr("WGDEVICE_A_PEERS")
+        if not isinstance(peers, (list, tuple)):
+            continue
+        for peer in peers:
+            try:
+                if _peer_public_key(peer) != public_key:
+                    continue
+                allowed_ips = peer.get_attr("WGPEER_A_ALLOWEDIPS")
+            except (UnicodeDecodeError, ValueError, AttributeError):
+                continue
+            if not isinstance(allowed_ips, (list, tuple)):
+                continue
+            for allowed_ip in allowed_ips:
+                address = (
+                    allowed_ip.get("addr") if isinstance(allowed_ip, dict) else None
+                )
+                if not isinstance(address, str):
+                    continue
+                try:
+                    network = ipaddress.ip_network(address, strict=False)
+                except ValueError:
+                    continue
+                if network.version == 6 and network.prefixlen == prefix_length:
+                    prefixes.add(str(network))
+    return sorted(prefixes)
+
+
+def find_stale_wireguard_clients(
+    parker: bool,
+    wg_interface: str,
+    *,
+    stale_timeout: Optional[float] = None,
+    initial_handshake_grace: float = _INITIAL_HANDSHAKE_GRACE,
+    parker_prefix_length: int = 63,
+    coordinator: PeerMutationCoordinator = peer_mutations,
+    clock: Callable[[], float] = time,
+) -> List[StaleWireGuardPeer]:
     """Fetches and returns a list of peers which have not had recent handshakes.
 
     Arguments:
@@ -238,38 +695,67 @@ def find_stale_wireguard_clients(parker: bool, wg_interface: str) -> List:
     Returns:
         # A list of peers which have not recently seen a handshake.
     """
-    three_hrs_in_secs = int(
-        (datetime.now() - timedelta(hours=_PEER_TIMEOUT_HOURS)).timestamp()
-    )
-    five_mins_in_secs = int((datetime.now() - timedelta(minutes=5)).timestamp())
+    if stale_timeout is None:
+        stale_timeout = _PARKER_STALE_TIMEOUT if parker else _LEGACY_STALE_TIMEOUT
+    now = clock()
+    stale_before = now - stale_timeout
     logger.info(
         "Starting search for stale wireguard peers for interface %s.", wg_interface
     )
     with pyroute2.WireGuard() as wg:
         all_peers = []
-        msgs = wg.info(wg_interface)
+        msgs = _wireguard_info(wg, wg_interface)
         logger.debug("Got infos for stale peers: %s.", msgs)
         for msg in msgs:
             peers = msg.get_attr("WGDEVICE_A_PEERS")
-            logger.debug("Got clients: %s.", peers)
+            if peers is not None and not isinstance(peers, (list, tuple)):
+                logger.warning(
+                    "Skipping malformed WireGuard peer list interface=%s",
+                    wg_interface,
+                )
+                continue
             if peers:
                 all_peers.extend(peers)
 
-        ret = [
-            (
-                peer.get_attr("WGPEER_A_PUBLIC_KEY").decode("utf-8"),
-                (
-                    allowed_ips[0].get("addr")  # addr contains the prefix as string
-                    if parker and (allowed_ips := peer.get_attr("WGPEER_A_ALLOWEDIPS"))
-                    else None
-                ),
+        stale_peers = []
+        for peer_index, peer in enumerate(all_peers):
+            try:
+                public_key = _peer_public_key(peer)
+                last_handshake = _last_handshake_seconds(peer)
+                if coordinator.recently_provisioned(
+                    public_key, initial_handshake_grace
+                ):
+                    continue
+                if last_handshake in (None, 0):
+                    if coordinator.defer_never_handshaked(
+                        public_key, initial_handshake_grace
+                    ):
+                        continue
+                    reason = "never_handshaked"
+                elif last_handshake <= stale_before:
+                    reason = "stale_handshake"
+                else:
+                    continue
+                parker_prefix = (
+                    _parker_prefix(peer, parker_prefix_length) if parker else None
+                )
+            except (UnicodeDecodeError, ValueError, AttributeError) as error:
+                logger.warning(
+                    "Skipping malformed WireGuard peer interface=%s "
+                    "peer_index=%s reason=%s",
+                    wg_interface,
+                    peer_index,
+                    error,
+                )
+                continue
+            stale_peers.append(
+                StaleWireGuardPeer(
+                    public_key=public_key,
+                    parker_prefix=parker_prefix,
+                    reason=reason,
+                )
             )
-            for peer in all_peers
-            if (hshk_time := peer.get_attr("WGPEER_A_LAST_HANDSHAKE_TIME")) is not None
-            and hshk_time.get("tv_sec", int())
-            < (five_mins_in_secs if parker else three_hrs_in_secs)
-        ]
-        return ret
+        return stale_peers
 
 
 def get_connected_peers_count(wg_interface: str) -> int:
@@ -287,13 +773,7 @@ def get_connected_peers_count(wg_interface: str) -> int:
     three_mins_ago_in_secs = int((datetime.now() - timedelta(minutes=3)).timestamp())
     logger.info("Counting connected wireguard peers for interface %s.", wg_interface)
     with pyroute2.WireGuard() as wg:
-        try:
-            msgs = wg.info(wg_interface)
-        except pyroute2.netlink.exceptions.NetlinkDumpInterrupted:
-            # Normal behaviour, data has changed while it was being returned by netlink.
-            # Retry once, don't catch the exception this time, and let the caller handle it.
-            # See https://github.com/svinota/pyroute2/issues/874
-            msgs = wg.info(wg_interface)
+        msgs = _wireguard_info(wg, wg_interface)
 
         logger.debug("Got infos for connected peers: %s.", msgs)
         count = 0

--- a/wgkex/worker/netlink.py
+++ b/wgkex/worker/netlink.py
@@ -260,8 +260,8 @@ def find_stale_wireguard_clients(parker: bool, wg_interface: str) -> List:
                 peer.get_attr("WGPEER_A_PUBLIC_KEY").decode("utf-8"),
                 (
                     allowed_ips[0].get("addr")  # addr contains the prefix as string
-                    if parker
-                    and len(allowed_ips := peer.get_attr("WGPEER_A_ALLOWEDIPS")) > 0
+                    # get_attr returns None when the peer has no allowed IPs.
+                    if parker and (allowed_ips := peer.get_attr("WGPEER_A_ALLOWEDIPS"))
                     else None
                 ),
             )

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -2,6 +2,7 @@
 
 # pyroute2 decides imports based on platform. WireGuard is specific to Linux only. Mock pyroute2.WireGuard so that
 # any testing platform can execute tests.
+import importlib
 import sys
 import unittest
 from datetime import datetime, timedelta
@@ -15,7 +16,11 @@ sys.modules["pyroute2"] = pyroute2_module_mock
 sys.modules["pyroute2.netlink"] = mock.MagicMock()
 from pyroute2 import IPRoute, WireGuard  # noqa: E402
 
-from wgkex.worker import netlink  # noqa: E402
+# Import netlink freshly so it binds to the pyroute2 mock above, even when an
+# earlier test module (e.g. msg_queue_test) already imported it against the
+# real pyroute2.
+sys.modules.pop("wgkex.worker.netlink", None)
+netlink = importlib.import_module("wgkex.worker.netlink")
 
 _WG_CLIENT_ADD = netlink.WireGuardClient(
     public_key="public_key", domain="add", remove=False

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -1,7 +1,6 @@
-"""Unit tests for netlink.py"""
+"""Behavioral tests for worker netlink cleanup."""
 
-# pyroute2 decides imports based on platform. WireGuard is specific to Linux only. Mock pyroute2.WireGuard so that
-# any testing platform can execute tests.
+import errno
 import importlib
 import sys
 import unittest
@@ -18,316 +17,493 @@ from pyroute2 import IPRoute, WireGuard  # noqa: E402
 
 sys.modules.pop("wgkex.worker.netlink", None)
 netlink = importlib.import_module("wgkex.worker.netlink")
-
-_WG_CLIENT_ADD = netlink.WireGuardClient(
-    public_key="public_key", domain="add", remove=False
-)
-_WG_CLIENT_DEL = netlink.WireGuardClient(
-    public_key="public_key", domain="del", remove=True
-)
+from wgkex.worker.peer_state import PeerMutationCoordinator  # noqa: E402
 
 
-def _get_peer_mock(public_key, last_handshake_time, has_allowed_ips=True):
-    def peer_get_attr(attr: str):
-        if attr == "WGPEER_A_LAST_HANDSHAKE_TIME":
-            return {"tv_sec": last_handshake_time}
-        if attr == "WGPEER_A_PUBLIC_KEY":
-            return public_key.encode()
-        if attr == "WGPEER_A_ALLOWEDIPS":
-            if not has_allowed_ips:
-                return None
-            return [
-                {
-                    "attrs": [
-                        ("WGALLOWEDIP_A_CIDR_MASK", 63),
-                        ("WGALLOWEDIP_A_FAMILY", 10),
-                        (
-                            "WGALLOWEDIP_A_IPADDR",
-                            "20:01:0d:b8:0e:d0:00:0a:00:00:00:00:00:00:00:00",
-                        ),
-                    ],
-                    "addr": "2001:db8:ed0:a::/63",
-                }
-            ]
+class MutableClock:
+    def __init__(self, now=100_000):
+        self.now = now
 
-    peer_mock = mock.Mock()
-    peer_mock.get_attr.side_effect = peer_get_attr
-    return peer_mock
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
 
 
-def _get_wg_mock(public_key, last_handshake_time, has_allowed_ips=True):
-    peer_mock = _get_peer_mock(public_key, last_handshake_time, has_allowed_ips)
+_DEFAULT_ALLOWED_IPS = object()
 
-    def msg_get_attr(attr: str):
-        if attr == "WGDEVICE_A_PEERS":
-            return [peer_mock]
 
-    msg_mock = mock.Mock()
-    msg_mock.get_attr.side_effect = msg_get_attr
-    wg_instance = WireGuard()
-    wg_info_mock = wg_instance.__enter__.return_value
-    wg_info_mock.set.return_value = {"WireGuard": "set"}
-    wg_info_mock.info.return_value = [msg_mock]
-    return wg_info_mock
+def _peer(
+    public_key="key",
+    handshake=100_000,
+    allowed_ips=_DEFAULT_ALLOWED_IPS,
+):
+    attrs = {
+        "WGPEER_A_PUBLIC_KEY": (
+            public_key.encode("ascii") if isinstance(public_key, str) else public_key
+        ),
+        "WGPEER_A_LAST_HANDSHAKE_TIME": (
+            {"tv_sec": handshake} if handshake is not None else None
+        ),
+        "WGPEER_A_ALLOWEDIPS": (
+            [{"addr": "2001:db8:1::/63"}]
+            if allowed_ips is _DEFAULT_ALLOWED_IPS
+            else allowed_ips
+        ),
+    }
+    peer = mock.Mock()
+    peer.get_attr.side_effect = attrs.get
+    return peer
+
+
+def _message(peers):
+    message = mock.Mock()
+    message.get_attr.side_effect = {
+        "WGDEVICE_A_PEERS": peers,
+        "WGDEVICE_A_LISTEN_PORT": 51820,
+        "WGDEVICE_A_PUBLIC_KEY": b"device-key",
+    }.get
+    return message
 
 
 class NetlinkTest(unittest.TestCase):
-    def setUp(self) -> None:
-        iproute_instance = IPRoute()
-        self.route_info_mock = iproute_instance.__enter__.return_value
-        # self.addCleanup(mock.patch.stopall)
+    def setUp(self):
+        self.wg = WireGuard().__enter__.return_value
+        self.wg.reset_mock()
+        self.wg.info.side_effect = None
+        self.ip = IPRoute().__enter__.return_value
+        self.ip.reset_mock()
+        self.ip.link_lookup.return_value = [7]
 
-    def test_find_stale_wireguard_clients_success_with_non_stale_peer(self):
-        """Tests find_stale_wireguard_clients no operation on non-stale peers."""
-        _wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        self.assertListEqual(
-            [], netlink.find_stale_wireguard_clients(False, "some_interface")
-        )
-
-    def test_find_stale_wireguard_clients_success_stale_peer(self):
-        """Tests find_stale_wireguard_clients removal of stale peer"""
-        _wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY_STALE",
-            int((datetime.now() - timedelta(hours=5)).timestamp()),
-        )
-        self.assertListEqual(
-            [("WGPEER_A_PUBLIC_KEY_STALE", None)],
-            netlink.find_stale_wireguard_clients(False, "some_interface"),
+    def _find(self, peers, parker=False, clock=None, coordinator=None, **kwargs):
+        clock = clock or MutableClock()
+        coordinator = coordinator or PeerMutationCoordinator(clock=clock)
+        self.wg.info.return_value = [_message(peers)]
+        return netlink.find_stale_wireguard_clients(
+            parker,
+            "wg-nodes" if parker else "wg-domain",
+            coordinator=coordinator,
+            clock=clock,
+            **kwargs,
         )
 
-    def test_stale_parker_peer_without_allowed_ips_does_not_abort_search(self):
-        _get_wg_mock(
-            "PARKER_PUBLIC_KEY",
-            int((datetime.now() - timedelta(hours=1)).timestamp()),
-            has_allowed_ips=False,
+    def test_handshake_cutoff_is_inclusive_and_mode_specific(self):
+        clock = MutableClock()
+        parker = self._find(
+            [
+                _peer("recent", clock.now - 299),
+                _peer("boundary", clock.now - 300),
+            ],
+            parker=True,
+            clock=clock,
+            stale_timeout=300,
+        )
+        self.assertEqual([peer.public_key for peer in parker], ["boundary"])
+
+        legacy = self._find(
+            [
+                _peer("recent", clock.now - 10799),
+                _peer("boundary", clock.now - 10800),
+            ],
+            clock=clock,
+            stale_timeout=10800,
+        )
+        self.assertEqual([peer.public_key for peer in legacy], ["boundary"])
+
+    def test_never_handshaked_peers_get_grace_then_become_stale(self):
+        for handshake in (0, None):
+            with self.subTest(handshake=handshake):
+                clock = MutableClock()
+                coordinator = PeerMutationCoordinator(clock=clock)
+                peers = [_peer("never", handshake)]
+                self.assertEqual(
+                    self._find(
+                        peers,
+                        clock=clock,
+                        coordinator=coordinator,
+                        initial_handshake_grace=600,
+                    ),
+                    [],
+                )
+                clock.advance(600)
+                result = self._find(
+                    peers,
+                    clock=clock,
+                    coordinator=coordinator,
+                    initial_handshake_grace=600,
+                )
+                self.assertEqual(result[0].reason, "never_handshaked")
+
+    def test_recent_queue_update_refreshes_grace_for_stale_peer(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        coordinator.record_provisioned("key")
+        peers = [_peer("key", clock.now - 1000)]
+
+        clock.advance(599)
+        self.assertEqual(
+            self._find(
+                peers,
+                parker=True,
+                clock=clock,
+                coordinator=coordinator,
+                stale_timeout=300,
+                initial_handshake_grace=600,
+            ),
+            [],
+        )
+        clock.advance(1)
+        self.assertEqual(
+            self._find(
+                peers,
+                parker=True,
+                clock=clock,
+                coordinator=coordinator,
+                stale_timeout=300,
+                initial_handshake_grace=600,
+            )[0].public_key,
+            "key",
         )
 
-        self.assertListEqual(
-            [("PARKER_PUBLIC_KEY", None)],
-            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
+    def test_parker_prefix_is_selected_from_all_allowed_ips(self):
+        result = self._find(
+            [
+                _peer(
+                    "key",
+                    1,
+                    [
+                        {"addr": "fe80::1/128"},
+                        {"addr": "192.0.2.1/32"},
+                        {"addr": "2001:db8:20::1/63"},
+                    ],
+                )
+            ],
+            parker=True,
+            stale_timeout=300,
+        )
+        self.assertEqual(result[0].parker_prefix, "2001:db8:20::/63")
+
+    def test_malformed_peers_are_skipped_without_aborting_sweep(self):
+        malformed_handshake = _peer("bad-handshake", 1)
+        malformed_handshake.get_attr.side_effect = {
+            "WGPEER_A_PUBLIC_KEY": b"bad-handshake",
+            "WGPEER_A_LAST_HANDSHAKE_TIME": {"tv_sec": "old"},
+        }.get
+        result = self._find(
+            [
+                _peer(None, 1),
+                malformed_handshake,
+                _peer(
+                    "ambiguous",
+                    1,
+                    [
+                        {"addr": "2001:db8:1::/63"},
+                        {"addr": "2001:db8:2::/63"},
+                    ],
+                ),
+                _peer("valid", 1),
+            ],
+            parker=True,
+            stale_timeout=300,
+        )
+        self.assertEqual([peer.public_key for peer in result], ["valid"])
+
+    def test_stale_parker_peer_without_allowed_ips_is_skipped(self):
+        result = self._find(
+            [
+                _peer("without-allowed-ips", 1, None),
+                _peer("valid", 1),
+            ],
+            parker=True,
+            stale_timeout=300,
+        )
+        self.assertEqual([peer.public_key for peer in result], ["valid"])
+
+    def test_netlink_dump_interruption_retries_once(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        self.wg.info.side_effect = [
+            pyroute2_netlink_exceptions.NetlinkDumpInterrupted(),
+            [_message([_peer("key", 1)])],
+        ]
+        result = netlink.find_stale_wireguard_clients(
+            False,
+            "wg-domain",
+            stale_timeout=300,
+            coordinator=coordinator,
+            clock=clock,
+        )
+        self.assertEqual(result[0].public_key, "key")
+        self.assertEqual(self.wg.info.call_count, 2)
+
+        self.wg.info.reset_mock()
+        self.wg.info.side_effect = pyroute2_netlink_exceptions.NetlinkDumpInterrupted()
+        with self.assertRaises(pyroute2_netlink_exceptions.NetlinkDumpInterrupted):
+            netlink.find_stale_wireguard_clients(
+                False,
+                "wg-domain",
+                coordinator=coordinator,
+                clock=clock,
+            )
+        self.assertEqual(self.wg.info.call_count, 2)
+
+    def test_parker_and_legacy_deletion_order(self):
+        for client, expected in (
+            (
+                netlink.ParkerWireGuardClient("key", "2001:db8::/63", True),
+                ["route", "wireguard"],
+            ),
+            (
+                netlink.WireGuardClient("key", "domain", True),
+                ["bridge_fdb", "route", "wireguard"],
+            ),
+        ):
+            calls = []
+            with (
+                mock.patch.object(
+                    netlink,
+                    "bridge_fdb_handler",
+                    side_effect=lambda _: calls.append("bridge_fdb") or {},
+                ),
+                mock.patch.object(
+                    netlink,
+                    "route_handler",
+                    side_effect=lambda _: calls.append("route") or {},
+                ),
+                mock.patch.object(
+                    netlink,
+                    "update_wireguard_peer",
+                    side_effect=lambda _: calls.append("wireguard") or {},
+                ),
+            ):
+                outcomes = netlink.link_handler(client)
+            self.assertEqual(calls, expected)
+            self.assertEqual(list(outcomes), expected)
+            self.assertTrue(
+                all(outcome.status == "deleted" for outcome in outcomes.values())
+            )
+
+    def test_parker_shared_prefix_preserves_route(self):
+        client = netlink.ParkerWireGuardClient("stale", "2001:db8::/63", True)
+        with (
+            mock.patch.object(netlink, "route_handler") as route,
+            mock.patch.object(netlink, "update_wireguard_peer", return_value={}),
+        ):
+            outcomes = netlink.link_handler(client, preserve_parker_route=True)
+        route.assert_not_called()
+        self.assertEqual(outcomes["route"].status, "preserved_shared")
+        self.assertEqual(outcomes["wireguard"].status, "deleted")
+
+    def test_parker_reassignment_removes_old_route_after_new_route(self):
+        client = netlink.ParkerWireGuardClient(
+            "key",
+            "2001:db8:2::/63",
+            False,
+            previous_ranges6=("2001:db8:1::/63",),
+        )
+        calls = []
+
+        def route_handler(route_client):
+            calls.append(
+                (
+                    "delete" if route_client.remove else "replace",
+                    route_client.range6,
+                )
+            )
+            return {}
+
+        with (
+            mock.patch.object(
+                netlink,
+                "update_wireguard_peer",
+                side_effect=lambda _: calls.append(("wireguard", None)) or {},
+            ),
+            mock.patch.object(netlink, "route_handler", side_effect=route_handler),
+        ):
+            outcomes = netlink.link_handler(client)
+
+        self.assertEqual(
+            calls,
+            [
+                ("wireguard", None),
+                ("replace", "2001:db8:2::/63"),
+                ("delete", "2001:db8:1::/63"),
+            ],
+        )
+        self.assertEqual(outcomes["old_route:2001:db8:1::/63"].status, "deleted")
+
+    def test_parker_prefix_ownership_checks_all_current_peers(self):
+        self.wg.info.return_value = [
+            _message(
+                [
+                    _peer(
+                        "stale",
+                        1,
+                        [{"addr": "2001:db8:20::/63"}],
+                    ),
+                    _peer(
+                        "active",
+                        100_000,
+                        [{"addr": "2001:db8:20::/63"}],
+                    ),
+                ]
+            )
+        ]
+        self.assertTrue(
+            netlink.parker_prefix_owned_by_other_peer(
+                "wg-nodes", "2001:db8:20::/63", "stale", 63
+            )
         )
 
-    def test_route_handler_add_success(self):
-        """Test route_handler for normal add operation."""
-        self.route_info_mock.route.return_value = {"key": "value"}
-        self.assertDictEqual({"key": "value"}, netlink.route_handler(_WG_CLIENT_ADD))
-        self.route_info_mock.route.assert_called_with(
-            "replace", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
+    def test_current_parker_prefixes_are_discovered_for_update(self):
+        self.wg.info.return_value = [
+            _message(
+                [
+                    _peer(
+                        "other",
+                        1,
+                        [{"addr": "2001:db8:10::/63"}],
+                    ),
+                    _peer(
+                        "key",
+                        1,
+                        [
+                            {"addr": "fe80::1/128"},
+                            {"addr": "2001:db8:20::1/63"},
+                        ],
+                    ),
+                ]
+            )
+        ]
+        self.assertEqual(
+            netlink.get_parker_prefixes_for_peer("wg-nodes", "key", 63),
+            ["2001:db8:20::/63"],
         )
 
-    def test_route_handler_remove_success(self):
-        """Test route_handler for normal del operation."""
-        self.route_info_mock.route.return_value = {"key": "value"}
-        self.assertDictEqual({"key": "value"}, netlink.route_handler(_WG_CLIENT_DEL))
-        self.route_info_mock.route.assert_called_with(
-            "del", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
-        )
+    def test_partial_failure_stops_before_peer_and_is_explicit(self):
+        client = netlink.WireGuardClient("key", "domain", True)
+        with (
+            mock.patch.object(netlink, "bridge_fdb_handler", return_value={}),
+            mock.patch.object(
+                netlink, "route_handler", side_effect=RuntimeError("route failed")
+            ),
+            mock.patch.object(netlink, "update_wireguard_peer") as remove_peer,
+            self.assertRaises(netlink.PeerMutationError) as raised,
+        ):
+            netlink.link_handler(client)
 
-    def test_update_wireguard_peer_success(self):
-        """Test update_wireguard_peer for normal operation."""
-        wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        self.assertDictEqual(
-            {"WireGuard": "set"}, netlink.update_wireguard_peer(_WG_CLIENT_ADD)
-        )
-        wg_info_mock.set.assert_called_with(
-            interface="wg-add",
-            peer={
-                "public_key": "public_key",
-                "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
-                "remove": False,
-            },
-        )
+        self.assertEqual(raised.exception.operation, "route")
+        self.assertEqual(list(raised.exception.operations), ["bridge_fdb"])
+        remove_peer.assert_not_called()
 
-    def test_bridge_fdb_handler_append_success(self):
-        """Test bridge_fdb_handler for normal append operation."""
-        self.route_info_mock.fdb.return_value = {"key": "value"}
-        self.assertEqual({"key": "value"}, netlink.bridge_fdb_handler(_WG_CLIENT_ADD))
-        self.route_info_mock.fdb.assert_called_with(
-            "append",
-            lladdr="00:00:00:00:00:00",
-            dst="fe80::282:6eff:fe9d:ecd3",
-            ifindex=mock.ANY,
-            NDA_IFINDEX=mock.ANY,
-        )
+    def test_already_absent_dependency_is_idempotent(self):
+        client = netlink.ParkerWireGuardClient("key", "2001:db8::/63", True)
+        absent = pyroute2_netlink_exceptions.NetlinkError(errno.ENOENT)
+        with (
+            mock.patch.object(netlink, "route_handler", side_effect=absent),
+            mock.patch.object(netlink, "update_wireguard_peer", return_value={}),
+        ):
+            outcomes = netlink.link_handler(client)
+        self.assertEqual(outcomes["route"].status, "already_absent")
+        self.assertEqual(outcomes["wireguard"].status, "deleted")
 
-    def test_bridge_fdb_handler_del_success(self):
-        """Test bridge_fdb_handler for normal del operation."""
-        self.route_info_mock.fdb.return_value = {"key": "value"}
-        self.assertEqual({"key": "value"}, netlink.bridge_fdb_handler(_WG_CLIENT_DEL))
-        self.route_info_mock.fdb.assert_called_with(
+    def test_failed_cleanup_is_selected_again_on_next_sweep(self):
+        stale = netlink.StaleWireGuardPeer("key", "2001:db8::/63", "stale")
+        client = netlink.ParkerWireGuardClient("key", "2001:db8::/63", True)
+        failure = netlink.PeerMutationError("route", client, {}, RuntimeError("failed"))
+        with (
+            mock.patch.object(
+                netlink, "find_stale_wireguard_clients", return_value=[stale]
+            ) as find,
+            mock.patch.object(
+                netlink,
+                "link_handler",
+                side_effect=[
+                    failure,
+                    {
+                        "route": netlink.OperationOutcome("deleted"),
+                        "wireguard": netlink.OperationOutcome("deleted"),
+                    },
+                ],
+            ),
+        ):
+            first = netlink.wg_flush_stale_peers(True)
+            second = netlink.wg_flush_stale_peers(True)
+
+        self.assertEqual(first[0].status, "failed")
+        self.assertEqual(first[0].failed_operation, "route")
+        self.assertEqual(second[0].status, "deleted")
+        self.assertEqual(find.call_count, 4)
+
+    def test_peer_that_becomes_active_after_scan_is_deferred(self):
+        stale = netlink.StaleWireGuardPeer("key", None, "stale")
+        with (
+            mock.patch.object(
+                netlink,
+                "find_stale_wireguard_clients",
+                side_effect=[[stale], []],
+            ),
+            mock.patch.object(netlink, "link_handler") as delete_peer,
+        ):
+            result = netlink.wg_flush_stale_peers(False, "domain")
+        self.assertEqual(result[0].status, "deferred")
+        delete_peer.assert_not_called()
+
+    def test_pending_old_parker_route_is_retried(self):
+        coordinator = PeerMutationCoordinator()
+        coordinator.record_pending_parker_route("2001:db8:1::/63")
+        with (
+            mock.patch.object(
+                netlink,
+                "parker_prefix_owned_by_other_peer",
+                return_value=False,
+            ),
+            mock.patch.object(netlink, "route_handler", return_value={}) as route,
+        ):
+            netlink.retry_pending_parker_routes(
+                coordinator=coordinator, prefix_length=63
+            )
+        route.assert_called_once()
+        self.assertEqual(coordinator.pending_parker_routes(), ())
+
+    def test_route_fdb_and_wireguard_handlers(self):
+        legacy = netlink.WireGuardClient("public_key", "domain", True)
+        self.ip.route.return_value = {"route": "deleted"}
+        self.ip.fdb.return_value = {"fdb": "deleted"}
+        self.wg.set.return_value = {"peer": "deleted"}
+
+        self.assertEqual(netlink.route_handler(legacy), {"route": "deleted"})
+        self.assertEqual(netlink.bridge_fdb_handler(legacy), {"fdb": "deleted"})
+        self.assertEqual(netlink.update_wireguard_peer(legacy), {"peer": "deleted"})
+        self.ip.route.assert_called_with("del", dst=legacy.lladdr, oif=mock.ANY)
+        self.ip.fdb.assert_called_with(
             "del",
             ifindex=mock.ANY,
-            NDA_IFINDEX=mock.ANY,
             lladdr="00:00:00:00:00:00",
-            dst="fe80::282:6eff:fe9d:ecd3",
-        )
-
-    def test_link_handler_addition_success(self):
-        """Test link_handler for normal operation."""
-        expected = {
-            "Wireguard": {"WireGuard": "set"},
-            "Route": {"IPRoute": "route"},
-            "Bridge FDB": {"IPRoute": "fdb"},
-        }
-        wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        wg_info_mock.set.return_value = {"WireGuard": "set"}
-        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
-        self.route_info_mock.route.return_value = {"IPRoute": "route"}
-        self.assertEqual(expected, netlink.link_handler(_WG_CLIENT_ADD))
-        self.route_info_mock.fdb.assert_called_with(
-            "append",
-            ifindex=mock.ANY,
+            dst=legacy.lladdr.removesuffix("/128"),
             NDA_IFINDEX=mock.ANY,
-            lladdr="00:00:00:00:00:00",
-            dst="fe80::282:6eff:fe9d:ecd3",
-        )
-        self.route_info_mock.route.assert_called_with(
-            "replace", dst="fe80::282:6eff:fe9d:ecd3/128", oif=mock.ANY
-        )
-        wg_info_mock.set.assert_called_with(
-            interface="wg-add",
-            peer={
-                "public_key": "public_key",
-                "allowed_ips": ["fe80::282:6eff:fe9d:ecd3/128"],
-                "remove": False,
-            },
         )
 
-    def test_wg_flush_stale_peers_not_stale_success(self):
-        """Tests processing of non-stale WireGuard Peer."""
-        _wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY",
-            int((datetime.now() - timedelta(seconds=3)).timestamp()),
-        )
-        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
-        self.route_info_mock.route.return_value = {"IPRoute": "route"}
-        self.assertListEqual([], netlink.wg_flush_stale_peers(False, "domain"))
-        # TODO(ruairi): Understand why pyroute.WireGuard.set
-        # wg_info_mock.set.assert_not_called()
-
-    def test_wg_flush_stale_peers_stale_success(self):
-        """Tests processing of stale WireGuard Peer."""
-        expected = [
-            {
-                "Wireguard": {"WireGuard": "set"},
-                "Route": {"IPRoute": "route"},
-                "Bridge FDB": {"IPRoute": "fdb"},
-            }
-        ]
-        self.route_info_mock.fdb.return_value = {"IPRoute": "fdb"}
-        self.route_info_mock.route.return_value = {"IPRoute": "route"}
-        wg_info_mock = _get_wg_mock(
-            "WGPEER_A_PUBLIC_KEY_STALE",
-            int((datetime.now() - timedelta(hours=5)).timestamp()),
-        )
-        wg_info_mock.set.return_value = {"WireGuard": "set"}
-        self.assertListEqual(expected, netlink.wg_flush_stale_peers(False, "domain"))
-        self.route_info_mock.route.assert_called_with(
-            "del", dst="fe80::281:16ff:fe49:395e/128", oif=mock.ANY
-        )
-
-    def test_get_connected_peers_count_success(self):
-        """Tests getting the correct number of connected peers for an interface."""
-        peers = []
-        for i in range(10):
-            peer_mock = _get_peer_mock(
-                "TEST_KEY",
-                int((datetime.now() - timedelta(minutes=i, seconds=5)).timestamp()),
+    def test_connected_count_and_device_data(self):
+        now = datetime.now()
+        peers = [
+            _peer(
+                f"key-{minutes}",
+                int((now - timedelta(minutes=minutes)).timestamp()),
             )
-            peers.append(peer_mock)
-
-        def msg_get_attr(attr: str):
-            if attr == "WGDEVICE_A_PEERS":
-                return peers
-
-        msg_mock = mock.Mock()
-        msg_mock.get_attr.side_effect = msg_get_attr
-
-        wg_instance = WireGuard()
-        wg_info_mock = wg_instance.__enter__.return_value
-        wg_info_mock.info.return_value = [msg_mock]
-
-        ret = netlink.get_connected_peers_count("wg-welt")
-        self.assertEqual(ret, 3)
-
-    @mock.patch("pyroute2.WireGuard")
-    def test_get_connected_peers_count_NetlinkDumpInterrupted(self, pyroute2_wg_mock):
-        """Tests getting the correct number of connected peers for an interface."""
-
-        nl_wg_mock_ctx = mock.MagicMock()
-        wg_info_mock = mock.MagicMock(
-            side_effect=(pyroute2_netlink_exceptions.NetlinkDumpInterrupted),
-        )
-        nl_wg_mock_ctx.info = wg_info_mock
-
-        nl_wg_mock_inst = pyroute2_wg_mock.return_value
-        nl_wg_mock_inst.__enter__ = mock.MagicMock(return_value=nl_wg_mock_ctx)
-
-        self.assertRaises(
-            pyroute2_netlink_exceptions.NetlinkDumpInterrupted,
-            netlink.get_connected_peers_count,
-            "wg-welt",
-        )
-        self.assertTrue(len(wg_info_mock.mock_calls) == 2)
-
-    def test_get_device_data_success(self):
-        def msg_get_attr(attr: str):
-            if attr == "WGDEVICE_A_LISTEN_PORT":
-                return 51820
-            if attr == "WGDEVICE_A_PUBLIC_KEY":
-                return "TEST_PUBLIC_KEY".encode("ascii")
-
-        msg_mock = mock.Mock()
-        msg_mock.get_attr.side_effect = msg_get_attr
-
-        wg_instance = WireGuard()
-        wg_info_mock = wg_instance.__enter__.return_value
-        wg_info_mock.info.return_value = [msg_mock]
-
-        ret = netlink.get_device_data("wg-welt")
-        self.assertTupleEqual(ret, (51820, "TEST_PUBLIC_KEY", mock.ANY))
-
-    def test_find_stale_wireguard_clients_parker_stale_peer(self):
-        """Tests find_stale_wireguard_clients in parker mode returning range6."""
-
-        _ = _get_wg_mock(
-            "PARKER_PUBLIC_KEY", int((datetime.now() - timedelta(hours=1)).timestamp())
-        )
-
-        self.assertListEqual(
-            [("PARKER_PUBLIC_KEY", "2001:db8:ed0:a::/63")],
-            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
-        )
-
-    def test_wg_flush_stale_peers_parker_stale_success(self):
-        """Tests processing of stale WireGuard Peer in parker mode."""
-
-        _ = _get_wg_mock(
-            "PARKER_PUBLIC_KEY", int((datetime.now() - timedelta(hours=1)).timestamp())
-        )
-
-        expected = [
-            {
-                "Wireguard": {"WireGuard": "set"},
-                "Route": {"IPRoute": "route"},
-            }
+            for minutes in range(5)
         ]
+        self.wg.info.return_value = [_message(peers)]
+        self.assertEqual(netlink.get_connected_peers_count("wg-domain"), 3)
 
-        ret = netlink.wg_flush_stale_peers(True, "parker")
-        self.assertListEqual(expected, ret)
-
-        # Verify the stale peer resulted in a route deletion for the parker range
-        self.route_info_mock.route.assert_called_with(
-            "del", dst="2001:db8:ed0:a::/63", oif=mock.ANY
+        self.ip.get_addr.return_value = [
+            mock.Mock(get_attr=mock.Mock(return_value="fe80::1"))
+        ]
+        self.wg.info.return_value = [_message([])]
+        self.assertEqual(
+            netlink.get_device_data("wg-domain"),
+            (51820, "device-key", "fe80::1"),
         )
 
 

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -30,13 +30,17 @@ _WG_CLIENT_DEL = netlink.WireGuardClient(
 )
 
 
-def _get_peer_mock(public_key, last_handshake_time):
+def _get_peer_mock(public_key, last_handshake_time, has_allowed_ips=True):
     def peer_get_attr(attr: str):
         if attr == "WGPEER_A_LAST_HANDSHAKE_TIME":
             return {"tv_sec": last_handshake_time}
         if attr == "WGPEER_A_PUBLIC_KEY":
             return public_key.encode()
         if attr == "WGPEER_A_ALLOWEDIPS":
+            if not has_allowed_ips:
+                # The kernel omits the attribute for peers without allowed
+                # IPs, in which case get_attr returns None.
+                return None
             return [
                 {
                     "attrs": [
@@ -56,8 +60,8 @@ def _get_peer_mock(public_key, last_handshake_time):
     return peer_mock
 
 
-def _get_wg_mock(public_key, last_handshake_time):
-    peer_mock = _get_peer_mock(public_key, last_handshake_time)
+def _get_wg_mock(public_key, last_handshake_time, has_allowed_ips=True):
+    peer_mock = _get_peer_mock(public_key, last_handshake_time, has_allowed_ips)
 
     def msg_get_attr(attr: str):
         if attr == "WGDEVICE_A_PEERS":
@@ -294,6 +298,20 @@ class NetlinkTest(unittest.TestCase):
 
         self.assertListEqual(
             [("PARKER_PUBLIC_KEY", "2001:db8:ed0:a::/63")],
+            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
+        )
+
+    def test_find_stale_wireguard_clients_parker_stale_peer_without_allowed_ips(self):
+        """Tests that a stale peer without allowed IPs doesn't abort the search."""
+
+        _ = _get_wg_mock(
+            "PARKER_PUBLIC_KEY",
+            int((datetime.now() - timedelta(hours=1)).timestamp()),
+            has_allowed_ips=False,
+        )
+
+        self.assertListEqual(
+            [("PARKER_PUBLIC_KEY", None)],
             netlink.find_stale_wireguard_clients(True, "wg-nodes"),
         )
 

--- a/wgkex/worker/netlink_test.py
+++ b/wgkex/worker/netlink_test.py
@@ -16,9 +16,6 @@ sys.modules["pyroute2"] = pyroute2_module_mock
 sys.modules["pyroute2.netlink"] = mock.MagicMock()
 from pyroute2 import IPRoute, WireGuard  # noqa: E402
 
-# Import netlink freshly so it binds to the pyroute2 mock above, even when an
-# earlier test module (e.g. msg_queue_test) already imported it against the
-# real pyroute2.
 sys.modules.pop("wgkex.worker.netlink", None)
 netlink = importlib.import_module("wgkex.worker.netlink")
 
@@ -38,8 +35,6 @@ def _get_peer_mock(public_key, last_handshake_time, has_allowed_ips=True):
             return public_key.encode()
         if attr == "WGPEER_A_ALLOWEDIPS":
             if not has_allowed_ips:
-                # The kernel omits the attribute for peers without allowed
-                # IPs, in which case get_attr returns None.
                 return None
             return [
                 {
@@ -101,6 +96,18 @@ class NetlinkTest(unittest.TestCase):
         self.assertListEqual(
             [("WGPEER_A_PUBLIC_KEY_STALE", None)],
             netlink.find_stale_wireguard_clients(False, "some_interface"),
+        )
+
+    def test_stale_parker_peer_without_allowed_ips_does_not_abort_search(self):
+        _get_wg_mock(
+            "PARKER_PUBLIC_KEY",
+            int((datetime.now() - timedelta(hours=1)).timestamp()),
+            has_allowed_ips=False,
+        )
+
+        self.assertListEqual(
+            [("PARKER_PUBLIC_KEY", None)],
+            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
         )
 
     def test_route_handler_add_success(self):
@@ -298,20 +305,6 @@ class NetlinkTest(unittest.TestCase):
 
         self.assertListEqual(
             [("PARKER_PUBLIC_KEY", "2001:db8:ed0:a::/63")],
-            netlink.find_stale_wireguard_clients(True, "wg-nodes"),
-        )
-
-    def test_find_stale_wireguard_clients_parker_stale_peer_without_allowed_ips(self):
-        """Tests that a stale peer without allowed IPs doesn't abort the search."""
-
-        _ = _get_wg_mock(
-            "PARKER_PUBLIC_KEY",
-            int((datetime.now() - timedelta(hours=1)).timestamp()),
-            has_allowed_ips=False,
-        )
-
-        self.assertListEqual(
-            [("PARKER_PUBLIC_KEY", None)],
             netlink.find_stale_wireguard_clients(True, "wg-nodes"),
         )
 

--- a/wgkex/worker/peer_state.py
+++ b/wgkex/worker/peer_state.py
@@ -1,0 +1,127 @@
+"""Bounded worker-local state used to coordinate peer mutations."""
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Iterable
+from contextlib import contextmanager
+from typing import Callable, Iterator
+
+
+class PeerMutationCoordinator:
+    """Coordinates per-peer mutations and tracks recent provisioning."""
+
+    def __init__(
+        self,
+        clock: Callable[[], float] = time.monotonic,
+        lock_stripes: int = 256,
+        max_provisioned_peers: int = 65536,
+    ) -> None:
+        if lock_stripes <= 0:
+            raise ValueError("lock_stripes must be positive")
+        if max_provisioned_peers <= 0:
+            raise ValueError("max_provisioned_peers must be positive")
+
+        self._clock = clock
+        self._locks = tuple(threading.RLock() for _ in range(lock_stripes))
+        self._max_provisioned_peers = max_provisioned_peers
+        self._provisioned_at: OrderedDict[str, float] = OrderedDict()
+        self._pending_parker_routes: OrderedDict[str, None] = OrderedDict()
+        self._state_lock = threading.Lock()
+        self._started_at = clock()
+
+    @contextmanager
+    def peer_lock(
+        self,
+        public_key: str,
+        related_resources: str | Iterable[str] | None = None,
+    ) -> Iterator[None]:
+        """Lock a peer and optional related resources in stable order."""
+        resources = [f"peer:{public_key}"]
+        if isinstance(related_resources, str):
+            related_resources = [related_resources]
+        if related_resources is not None:
+            resources.extend(f"resource:{resource}" for resource in related_resources)
+        lock_indexes = sorted(
+            {hash(resource) % len(self._locks) for resource in resources}
+        )
+        locks = [self._locks[index] for index in lock_indexes]
+        for lock in locks:
+            lock.acquire()
+        try:
+            yield
+        finally:
+            for lock in reversed(locks):
+                lock.release()
+
+    def _prune_expired(self, now: float) -> None:
+        expired = [
+            public_key
+            for public_key, expires_at in self._provisioned_at.items()
+            if expires_at <= now
+        ]
+        for public_key in expired:
+            del self._provisioned_at[public_key]
+
+    def record_provisioned(
+        self, public_key: str, retention_seconds: float = 600
+    ) -> None:
+        """Record an accepted queue update before applying it to netlink."""
+        now = self._clock()
+        with self._state_lock:
+            self._prune_expired(now)
+            if public_key in self._provisioned_at:
+                del self._provisioned_at[public_key]
+            elif len(self._provisioned_at) >= self._max_provisioned_peers:
+                raise RuntimeError("recent peer provisioning tracker is at capacity")
+            self._provisioned_at[public_key] = now + retention_seconds
+
+    def recently_provisioned(self, public_key: str, grace_seconds: float) -> bool:
+        """Return whether a peer has a queue update inside the grace period."""
+        now = self._clock()
+        with self._state_lock:
+            expires_at = self._provisioned_at.get(public_key)
+            if expires_at is None:
+                return False
+            if now < expires_at:
+                return True
+            del self._provisioned_at[public_key]
+            return False
+
+    def defer_never_handshaked(self, public_key: str, grace_seconds: float) -> bool:
+        """Protect never-handshaked peers after provisioning or worker restart."""
+        now = self._clock()
+        with self._state_lock:
+            expires_at = self._provisioned_at.get(public_key)
+            if expires_at is not None and now < expires_at:
+                return True
+            self._provisioned_at.pop(public_key, None)
+            return now - self._started_at < grace_seconds
+
+    def forget(self, public_key: str) -> None:
+        """Forget state for a peer after it has been removed."""
+        with self._state_lock:
+            self._provisioned_at.pop(public_key, None)
+
+    def record_pending_parker_route(self, prefix: str) -> None:
+        """Remember an old Parker route that still needs deletion."""
+        with self._state_lock:
+            if prefix in self._pending_parker_routes:
+                self._pending_parker_routes.move_to_end(prefix)
+                return
+            if len(self._pending_parker_routes) >= self._max_provisioned_peers:
+                raise RuntimeError("pending Parker route tracker is at capacity")
+            self._pending_parker_routes[prefix] = None
+
+    def pending_parker_routes(self) -> tuple[str, ...]:
+        """Return a snapshot of old Parker routes awaiting deletion."""
+        with self._state_lock:
+            return tuple(self._pending_parker_routes)
+
+    def forget_pending_parker_route(self, prefix: str) -> None:
+        """Forget an old Parker route after deletion or reassignment."""
+        with self._state_lock:
+            self._pending_parker_routes.pop(prefix, None)
+
+
+peer_mutations = PeerMutationCoordinator()

--- a/wgkex/worker/peer_state_test.py
+++ b/wgkex/worker/peer_state_test.py
@@ -1,0 +1,107 @@
+"""Tests for bounded peer mutation state."""
+
+import threading
+import unittest
+
+from wgkex.worker.peer_state import PeerMutationCoordinator
+
+
+class MutableClock:
+    def __init__(self):
+        self.now = 0
+
+    def __call__(self):
+        return self.now
+
+
+class PeerMutationCoordinatorTest(unittest.TestCase):
+    def test_provisioning_and_restart_grace_expire(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock)
+        self.assertTrue(coordinator.defer_never_handshaked("unknown", 10))
+        coordinator.record_provisioned("known", 10)
+
+        clock.now = 9
+        self.assertTrue(coordinator.recently_provisioned("known", 10))
+        clock.now = 10
+        self.assertFalse(coordinator.recently_provisioned("known", 10))
+        self.assertFalse(coordinator.defer_never_handshaked("unknown", 10))
+
+    def test_tracker_capacity_is_bounded_and_explicit(self):
+        clock = MutableClock()
+        coordinator = PeerMutationCoordinator(clock=clock, max_provisioned_peers=1)
+        coordinator.record_provisioned("first", 10)
+        with self.assertRaisesRegex(RuntimeError, "at capacity"):
+            coordinator.record_provisioned("second", 10)
+        self.assertTrue(coordinator.recently_provisioned("first", 10))
+        clock.now = 10
+        coordinator.record_provisioned("second", 10)
+        self.assertTrue(coordinator.recently_provisioned("second", 10))
+
+    def test_pending_parker_routes_are_bounded_and_removable(self):
+        coordinator = PeerMutationCoordinator(max_provisioned_peers=1)
+        coordinator.record_pending_parker_route("2001:db8:1::/63")
+        coordinator.record_pending_parker_route("2001:db8:1::/63")
+        with self.assertRaisesRegex(RuntimeError, "at capacity"):
+            coordinator.record_pending_parker_route("2001:db8:2::/63")
+        self.assertEqual(coordinator.pending_parker_routes(), ("2001:db8:1::/63",))
+        coordinator.forget_pending_parker_route("2001:db8:1::/63")
+        self.assertEqual(coordinator.pending_parker_routes(), ())
+
+    def test_same_peer_serializes_while_different_peers_do_not(self):
+        coordinator = PeerMutationCoordinator(lock_stripes=257)
+        entered = threading.Event()
+        release = threading.Event()
+        same_peer_entered = threading.Event()
+
+        def hold_lock():
+            with coordinator.peer_lock("peer"):
+                entered.set()
+                release.wait()
+
+        def wait_for_same_peer():
+            with coordinator.peer_lock("peer"):
+                same_peer_entered.set()
+
+        holder = threading.Thread(target=hold_lock)
+        waiter = threading.Thread(target=wait_for_same_peer)
+        holder.start()
+        entered.wait(timeout=1)
+        waiter.start()
+        self.assertFalse(same_peer_entered.wait(timeout=0.05))
+        with coordinator.peer_lock("other-peer"):
+            pass
+        release.set()
+        holder.join(timeout=1)
+        waiter.join(timeout=1)
+        self.assertTrue(same_peer_entered.is_set())
+
+    def test_related_resource_serializes_different_peers(self):
+        coordinator = PeerMutationCoordinator(lock_stripes=257)
+        entered = threading.Event()
+        release = threading.Event()
+        waiter_entered = threading.Event()
+
+        def hold_prefix():
+            with coordinator.peer_lock("old-key", "2001:db8::/63"):
+                entered.set()
+                release.wait()
+
+        def wait_for_prefix():
+            with coordinator.peer_lock("new-key", "2001:db8::/63"):
+                waiter_entered.set()
+
+        holder = threading.Thread(target=hold_prefix)
+        waiter = threading.Thread(target=wait_for_prefix)
+        holder.start()
+        entered.wait(timeout=1)
+        waiter.start()
+        self.assertFalse(waiter_entered.wait(timeout=0.05))
+        release.set()
+        holder.join(timeout=1)
+        waiter.join(timeout=1)
+        self.assertTrue(waiter_entered.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR semantically ports the still-relevant fixes from [`parker-new`](https://github.com/freifunkMUC/wgkex/tree/parker-new) onto the current `parker` head for #202, which already contains the accepted #276 implementation.

A direct merge was unsafe: it conflicts across the broker, both IPAM implementations, Parker selection, signing, configuration, and worker MQTT tests. More importantly, `parker-new` embeds audit merge `d031b09`, whose tree differs from the accepted #276 merge tree in seven files. This integration therefore skips that merge and its duplicate audit commits, evaluates each real first-parent fix, and preserves the stronger #276 behavior.

## Commit provenance

The 21 real `parker-new` first-parent fixes are retained as 21 commits in their original order. Each retains Grische's original author identity and complete original message, including the Claude Fable 5 co-author trailer. Only the final Annika-authored reconciliation commit contains integration-specific adaptations needed to preserve #276. No Copilot attribution is present.

## Semantic commit matrix

| `parker-new` fix | Classification | Integration decision |
|---|---|---|
| `8488143` disabled-Parker startup | Already covered by #276 | Retained as an intentional empty provenance commit; kept #276's startup guard and existing regression coverage. |
| `c9b99f7` selection debug print | Genuinely new; ported | Removed the leftover output from worker selection. |
| `8127424` NetBox IPv4 parent | Partially covered; adapted | Added address-family-specific parent selection while retaining #276's concurrent-allocation deduplication. |
| `78e37c4` IPv6 length mismatch | Partially covered; adapted | Kept #276's rejection of unusable prefixes; safe larger prefixes now warn rather than failing unnecessarily. |
| `a17799a` fallback worker ID | Genuinely new; ported | Emergency fallback returns the stable configured worker ID. |
| `b823c2e` persistence ordering | Genuinely new; ported | Selection is persisted only after a complete response is built successfully. |
| `2e66d14` explicit unique IDs | Genuinely new; ported | Documented IDs, enforced uniqueness, and strengthened validation to unsigned 32-bit values. |
| `a0577e5` JSON allocation locking | Already covered by #276 | Retained as an intentional empty provenance commit; kept #276's stronger locking, atomic replacement, fsync, permissions, and multiprocessing coverage. |
| `b6b394c` ParkerQuery dataclass init | Genuinely new; ported | Replaced the handwritten initializer with dataclass construction and `__post_init__` validation. |
| `4aebb71` discovery state leakage | Genuinely new; ported | Isolated shared test state so full discovery runs remain deterministic. |
| `9f16265` malformed worker logging | Genuinely new; ported | Corrected the cleanup logging call. |
| `4754e4e` malformed MQTT payloads | Genuinely new; ported | Narrowly handles malformed metrics/status payloads without killing the MQTT thread. |
| `77ccf80` stale peers without allowed IPs | Genuinely new; ported | Skips incomplete peers instead of aborting stale-peer discovery. |
| `6ae1ee7` missing `wg-nodes` | Genuinely new; ported | Publishes offline readiness, retries discovery, and recovers status/metrics when the interface appears. |
| `cde183f` encrypted/corrupt signify key | Genuinely new; ported | Explicitly rejects passphrase-protected and checksum-invalid signing keys. |
| `c8d5852` overlapping JSON allocations | Genuinely new; ported | Makes free-prefix selection overlap-aware on top of #276's atomic store. |
| `7012581` unconfigured fallback workers | Genuinely new; ported | Restricts fallback to configured workers with endpoint data and online status while tolerating missing metrics. |
| `10888ac` Parker broker counting | Genuinely new; ported | Counts only live brokers retaining Parker capability and clears stale capability when Parker is disabled. |
| `0b50687` sticky small targets | Genuinely new; ported | Applies a minimum slack so small healthy targets remain sticky. |
| `4d3a8d8` worker-vs-broker settings | Partially covered; adapted | Makes broker-only key/NetBox settings optional in shared config while preserving broker startup enforcement from #276. |
| `12d74af` explicit-null weight | Genuinely new; ported | Restores `null` compatibility while preserving explicit `weight: 0`. |

## Semantic conflict resolution

- Preserved #276's atomic JSON persistence and added overlap-aware allocation rather than replacing the implementation.
- Preserved #276's NetBox concurrency deduplication while fixing IPv4 parent-prefix lookup.
- Reconciled Parker selection, fallback, persistence ordering, and broker-count semantics instead of choosing either conflicting `app.py` wholesale.
- Kept accepted startup/signing/config requirements at broker boundaries while allowing the shared worker config to omit broker-only credentials.
- Strengthened missing-interface recovery, stale-capability cleanup, worker-ID range checks, and fallback readiness beyond the original fixes.
- Added or adapted regression tests across every retained behavior without removing #276 coverage.

## Validation

- Bazel 9 tests: all 14 targets passed.
- Python unittest discovery: 135 tests passed.
- Bazel coverage: **3175/3219 lines (98.63%)**, above `parker` at **2918/2964 (98.45%)** and `main` at **1008/1051 (95.91%)**.
- `bazel build //...` and module lock verification passed.
- Black and Ruff passed.
- Production and devcontainer amd64 images built successfully.
- Devcontainer Compose validation passed (apart from pre-existing obsolete `version` warnings).

Closes no issue; integration for #202. Retains the accepted behavior from #276 and ports fixes from `parker-new` without merging `d031b09`.
